### PR TITLE
Uses settings value directly for indicator visibility

### DIFF
--- a/HeadsetControl@lauinger-clan.de/extension.js
+++ b/HeadsetControl@lauinger-clan.de/extension.js
@@ -520,8 +520,9 @@ const HeadsetControlIndicator = GObject.registerClass(
             });
             this.add_child(this._indicatorLabel);
             this._indicator.icon_name = "audio-headset-symbolic";
-            let showIndicator = _settings.get_boolean("show-systemindicator");
-            this._indicator.visible = showIndicator;
+            this._indicator.visible = _settings.get_boolean(
+                "show-systemindicator"
+            );
             this._indicatorLabel.visible = false;
 
             // Create the toggle menu and associate it with the indicator, being


### PR DESCRIPTION
Simplifies system indicator visibility logic by directly
using the settings value, removing an unnecessary variable.
