### PR TITLE
Adds refresh interval setting

### DIFF
--- a/HeadsetControl@lauinger-clan.de/extension.js
+++ b/HeadsetControl@lauinger-clan.de/extension.js
@@ -1140,6 +1140,9 @@ export default class HeadsetControl extends Extension {
         this._hideWhenDisconnectedSystemindicator = this._settings.get_boolean(
             "hidewhendisconnected-systemindicator"
         );
+        this._refreshIntervalSystemindicator = this._settings.get_int(
+            "refreshinterval-systemindicator"
+        );
         if (!this._refreshJSONall(this._showIndicator)) {
             this._refreshCapabilities();
         }


### PR DESCRIPTION
Adds a setting to control the refresh interval for the system indicator.
This allows users to customize how frequently the system indicator is updated.
