### PR TITLE
Renames variable for clarity

### DIFF
--- a/HeadsetControl@lauinger-clan.de/extension.js
+++ b/HeadsetControl@lauinger-clan.de/extension.js
@@ -846,9 +846,10 @@ export default class HeadsetControl extends Extension {
             proc.init(null);
 
             const stdout = await new Promise((resolve, reject) => {
-                proc.communicate_async(null, null, (proc, res) => {
+                proc.communicate_async(null, null, (subprocess, res) => {
                     try {
-                        const [, stdoutFinish] = proc.communicate_finish(res);
+                        const [, stdoutFinish] =
+                            subprocess.communicate_finish(res);
                         resolve(stdoutFinish);
                     } catch (err) {
                         this._logOutput(


### PR DESCRIPTION
Renames the `proc` variable to `subprocess` within the
`communicate_async` callback function for enhanced code
readability and to accurately reflect its role as a subprocess.
