### PR TITLE
Guards against missing equalizer presets

### DIFF
--- a/HeadsetControl@lauinger-clan.de/extension.js
+++ b/HeadsetControl@lauinger-clan.de/extension.js
@@ -645,10 +645,12 @@ export default class HeadsetControl extends Extension {
         if ("equalizer_presets_count" in device) {
             this._logOutput("equalizer_presets_count: " + device.equalizer_presets_count);
             if (device.equalizer_presets_count > 0) {
-                // Get preset names from the keys of the equalizer_presets object
-                const presetNames = Object.keys(device.equalizer_presets);
-                this._logOutput("equalizer preset names: " + presetNames.join(", "));
-                this._settings.set_strv("equalizer-preset-names", presetNames);
+                if (Object.hasOwn(device, "equalizer_presets")) {
+                    // Get preset names from the keys of the equalizer_presets object
+                    const presetNames = Object.keys(device.equalizer_presets);
+                    this._logOutput("equalizer preset names: " + presetNames.join(", "));
+                    this._settings.set_strv("equalizer-preset-names", presetNames);
+                }
             }
         }
     }

--- a/HeadsetControl@lauinger-clan.de/metadata.json
+++ b/HeadsetControl@lauinger-clan.de/metadata.json
@@ -10,5 +10,5 @@
         "github": "ChrisLauinger77",
         "paypal": "ChrisLauinger"
     },
-    "version-name": "49.2"
+    "version-name": "49.3"
 }


### PR DESCRIPTION
Adds a check to ensure the `equalizer_presets` property exists before accessing its keys. This prevents errors when the property is not present in the device information.

Increments extension version.
