### PR TITLE
Adds prefer-const ESLint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -89,6 +89,7 @@ export default [
             ],
             'no-var': 'warn',
             'unicode-bom': 'error',
+            'prefer-const': 'error',
             // GJS Restrictions
             'no-restricted-globals': [
                 'error',


### PR DESCRIPTION
Enforces the use of `const` declarations for variables that are not reassigned after their initial assignment.

This improves code readability and helps prevent accidental reassignment of variables that should be constant.
