### PR TITLE
Allows partial device status as success

### DIFF
--- a/HeadsetControl@lauinger-clan.de/extension.js
+++ b/HeadsetControl@lauinger-clan.de/extension.js
@@ -623,7 +623,7 @@ export default class HeadsetControl extends Extension {
 
     _isDeviceStatusSuccess(device) {
         this._logOutput("device.status:" + " " + device.status);
-        return device.status && device.status.includes("success");
+        return typeof device.status === "string" && (device.status.includes("success") || device.status.includes("partial"));
     }
 
     _hasEqualizerPresetSupport(device) {

--- a/HeadsetControl@lauinger-clan.de/metadata.json
+++ b/HeadsetControl@lauinger-clan.de/metadata.json
@@ -10,5 +10,5 @@
         "github": "ChrisLauinger77",
         "paypal": "ChrisLauinger"
     },
-    "version-name": "49.5"
+    "version-name": "49.6"
 }


### PR DESCRIPTION
Extends device status check to include "partial" as a valid success state.

This allows devices with a "partial" status to be recognized as successfully connected and functioning, preventing false negatives.
