### PR TITLE
Simplify equalizer preset display in preferences

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,15 +17,15 @@ jobs:
             pull-requests: write
 
         steps:
-            - uses: actions/stale@v6
+            - uses: actions/stale@v10
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   stale-issue-label: "stale"
                   stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
                   close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
-                  stale-pr-message: "Stale pull request message"
+                  stale-pr-message: "This pull request is stale because it has been open for 30 days with no activity."
                   stale-pr-label: "no-pr-activity"
-                  days-before-issue-stale: 21
-                  days-before-issue-close: 7
+                  days-before-issue-stale: 30
+                  days-before-issue-close: 14
                   days-before-pr-stale: -1
                   days-before-pr-close: -1

--- a/HeadsetControl@lauinger-clan.de/metadata.json
+++ b/HeadsetControl@lauinger-clan.de/metadata.json
@@ -12,5 +12,5 @@
         "paypal": "ChrisLauinger"
     },
     "version": 999,
-    "version-name": "50.2"
+    "version-name": "50.3"
 }

--- a/HeadsetControl@lauinger-clan.de/prefs.js
+++ b/HeadsetControl@lauinger-clan.de/prefs.js
@@ -246,17 +246,8 @@ export default class AdwPrefs extends ExtensionPreferences {
         }
         //equalizer preset
         const arrayEQPnames = window._settings.get_strv("equalizer-preset-names");
-        const equalizerPresetLabels =
-            !arrayEQPnames || arrayEQPnames.length === 0
-                ? [_("Default"), _("Preset 1"), _("Preset 2"), _("Preset 3")]
-                : arrayEQPnames;
-        for (const [index, value] of equalizerPresetLabels.entries()) {
-            if (index >= 4) break;
-            const adwrowEQP = builder.get_object("HeadsetControl_row_equalizerpreset" + (index + 1));
-            if (!adwrowEQP) continue; // Prevent TypeError
-            adwrowEQP.set_text(_(value));
-            adwrowEQP.connect("changed", this._onEQvaluechanged.bind(this, adwrowEQP, index, "equalizer-preset-names"));
-        }
+        const adwrowEQP = builder.get_object("HeadsetControl_row_equalizerpreset1");
+        adwrowEQP.set_title(arrayEQPnames.toString());
         //sidetone
         const sidetoneLabels = [
             _("Value for Off"),

--- a/HeadsetControl@lauinger-clan.de/ui/prefs.ui
+++ b/HeadsetControl@lauinger-clan.de/ui/prefs.ui
@@ -266,26 +266,9 @@
             <property name="subtitle" translatable="yes">Names of the equalizer presets (equalizer preset might not be supported by your headset)</property>
             <property name="tooltip-text" translatable="yes">Names of the equalizer presets (equalizer preset might not be supported by your headset)</property>
             <child>
-              <object class="AdwEntryRow" id="HeadsetControl_row_equalizerpreset1">
+              <object class="AdwActionRow" id="HeadsetControl_row_equalizerpreset1">
                 <property name="title" translatable="yes">Default</property>
-                <property name="tooltip-text" translatable="yes">Shown in equalizer preset menu (when supported)</property>
-              </object>
-            </child>
-            <child>
-              <object class="AdwEntryRow" id="HeadsetControl_row_equalizerpreset2">
-                <property name="title" translatable="yes">Preset 1</property>
-                <property name="tooltip-text" translatable="yes">Shown in equalizer preset menu (when supported)</property>
-              </object>
-            </child>
-            <child>
-              <object class="AdwEntryRow" id="HeadsetControl_row_equalizerpreset3">
-                <property name="title" translatable="yes">Preset 2</property>
-                <property name="tooltip-text" translatable="yes">Shown in equalizer preset menu (when supported)</property>
-              </object>
-            </child>
-            <child>
-              <object class="AdwEntryRow" id="HeadsetControl_row_equalizerpreset4">
-                <property name="title" translatable="yes">Preset 3</property>
+                <property name="subtitle" translatable="yes">Shown in equalizer preset menu (when supported)</property>
                 <property name="tooltip-text" translatable="yes">Shown in equalizer preset menu (when supported)</property>
               </object>
             </child>


### PR DESCRIPTION
Consolidates the four individual equalizer preset entry rows into a single action row that displays the retrieved preset names as a string.
