### PR TITLE
Add configurable low battery notification threshold

### DIFF
--- a/HeadsetControl@lauinger-clan.de/extension.js
+++ b/HeadsetControl@lauinger-clan.de/extension.js
@@ -921,6 +921,7 @@ export default class HeadsetControl extends Extension {
 
     _onParamChangedLogNot() {
         this._notificationLowBattery = this._settings.get_boolean("notification-low-battery");
+        this._lowBatteryThreshold = this._settings.get_boolean("low-battery-threshold");
         this._useLogging = this._settings.get_boolean("use-logging");
         this._headsetControlIndicator.headsetControlMenuToggle.updateUseLogging(this._useLogging);
     }
@@ -1016,8 +1017,7 @@ export default class HeadsetControl extends Extension {
             return;
         }
         this._logOutput("_notifyLowBattery - strStatus: " + strStatus + " valueBatteryNum: " + valueBatteryNum);
-        const threshold = 25;
-        if (strStatus === "BATTERY_AVAILABLE" && valueBatteryNum <= threshold) {
+        if (strStatus === "BATTERY_AVAILABLE" && valueBatteryNum <= this._lowBatteryThreshold) {
             if (!this._batteryLowNotified) {
                 this._batteryLowNotified = true;
                 this._addNotification(
@@ -1027,7 +1027,7 @@ export default class HeadsetControl extends Extension {
                     "battery_low"
                 );
             }
-        } else if (strStatus === "BATTERY_CHARGING" || valueBatteryNum > threshold) {
+        } else if (strStatus === "BATTERY_CHARGING" || valueBatteryNum > this._lowBatteryThreshold) {
             this._batteryLowNotified = false;
             this._removeNotification("battery_low");
         }
@@ -1043,6 +1043,7 @@ export default class HeadsetControl extends Extension {
         this._headsetControlIndicator = new HeadsetControlIndicator(this);
         this._initCmd();
         this._notificationLowBattery = this._settings.get_boolean("notification-low-battery");
+        this._lowBatteryThreshold = this._settings.get_boolean("low-battery-threshold");
         this._useLogging = this._settings.get_boolean("use-logging");
         this._useColors = this._settings.get_boolean("use-colors");
         this._showIndicator = this._settings.get_boolean("show-systemindicator");
@@ -1101,6 +1102,7 @@ export default class HeadsetControl extends Extension {
                 callback: this._initCmd.bind(this),
             },
             { key: "notification-low-battery", callback: this._onParamChangedLogNot.bind(this) },
+            { key: "low-battery-threshold", callback: this._onParamChangedLogNot.bind(this) },
             { key: "use-logging", callback: this._onParamChangedLogNot.bind(this) },
             {
                 key: "show-systemindicator",
@@ -1166,6 +1168,7 @@ export default class HeadsetControl extends Extension {
         this._batteryLowNotified = null;
         this._refreshIntervalSystemindicator = null;
         this._notificationLowBattery = null;
+        this._lowBatteryThreshold = null;
         this._useLogging = null;
         this._useColors = null;
     }

--- a/HeadsetControl@lauinger-clan.de/metadata.json
+++ b/HeadsetControl@lauinger-clan.de/metadata.json
@@ -12,5 +12,5 @@
         "paypal": "ChrisLauinger"
     },
     "version": 999,
-    "version-name": "50.3"
+    "version-name": "50.4"
 }

--- a/HeadsetControl@lauinger-clan.de/prefs.js
+++ b/HeadsetControl@lauinger-clan.de/prefs.js
@@ -79,6 +79,11 @@ export default class AdwPrefs extends ExtensionPreferences {
         this.getSettings().set_int("refreshinterval-systemindicator", value);
     }
 
+    _onBTvaluechanged(adwrow) {
+        const value = adwrow.get_value();
+        this.getSettings().set_int("low-battery-threshold", value);
+    }
+
     _onQSToggleValuechanged(_settings, cmb) {
         _settings.set_int("quicksettings-toggle", cmb.get_selected());
     }
@@ -181,6 +186,10 @@ export default class AdwPrefs extends ExtensionPreferences {
         // notification for low battery
         adwrow = builder.get_object("HeadsetControl_row_notifications");
         window._settings.bind("notification-low-battery", adwrow, "active", Gio.SettingsBindFlags.DEFAULT);
+        // low battery threshold
+        adwrow = builder.get_object("HeadsetControl_row_lowbatterythreshold");
+        adwrow.set_value(this.getSettings().get_int("low-battery-threshold"));
+        adwrow.connect("changed", this._onBTvaluechanged.bind(this, adwrow));
         //use logging
         adwrow = builder.get_object("HeadsetControl_row_logging");
         window._settings.bind("use-logging", adwrow, "active", Gio.SettingsBindFlags.DEFAULT);

--- a/HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml
+++ b/HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml
@@ -135,5 +135,10 @@
       <summary>Inactive time values</summary>
       <description>Used for inactive time values (-1 disable)</description>
     </key>
+    <key name="low-battery-threshold" type="i">
+      <default>25</default>
+      <summary>Battery percentage to trigger low battery notification</summary>
+      <description>When battery percentage falls below this value, a low battery notification will be triggered</description>
+    </key>
   </schema>
 </schemalist>

--- a/HeadsetControl@lauinger-clan.de/ui/prefs.ui
+++ b/HeadsetControl@lauinger-clan.de/ui/prefs.ui
@@ -185,6 +185,22 @@
           </object>
         </child>
         <child>
+          <object class="AdwSpinRow" id="HeadsetControl_row_lowbatterythreshold">
+            <property name="title" translatable="yes">Threshold for low battery notification (%)</property>
+            <property name="subtitle" translatable="yes">Battery percentage to trigger low battery notification</property>
+            <property name="tooltip-text" translatable="yes">When battery percentage falls below this value, a low battery notification will be triggered</property>
+            <property name="adjustment">
+              <object class="GtkAdjustment">
+                <property name="lower">5</property>
+                <property name="upper">30</property>
+                <property name="value">1</property>
+                <property name="step-increment">1</property>
+                <property name="page-increment">5</property>
+              </object>
+            </property>
+          </object>
+        </child>
+        <child>
           <object class="AdwSwitchRow" id="HeadsetControl_row_logging">
             <property name="title" translatable="yes">Use logging</property>
             <property name="subtitle" translatable="yes">Enable / disable log outputs</property>

--- a/po/HeadsetControl.pot
+++ b/po/HeadsetControl.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-24 06:08+0200\n"
+"POT-Creation-Date: 2026-04-25 09:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -39,7 +39,7 @@ msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/extension.js:136
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:74
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:281
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:297
 msgid "Sidetone"
 msgstr ""
 
@@ -131,22 +131,22 @@ msgid " Minutes"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/extension.js:399
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:239
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:255
 msgid "Setting 1"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/extension.js:400
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:245
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:261
 msgid "Setting 2"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/extension.js:401
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:251
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:267
 msgid "Setting 3"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/extension.js:402
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:257
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:273
 msgid "Setting 4"
 msgstr ""
 
@@ -168,84 +168,84 @@ msgid "Battery low! Please charge your headset."
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/prefs.js:22
-#: HeadsetControl@lauinger-clan.de/prefs.js:104
+#: HeadsetControl@lauinger-clan.de/prefs.js:109
 msgid "Select headsetcontrol executable"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:253
-#: HeadsetControl@lauinger-clan.de/prefs.js:268
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:289
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:382
+#: HeadsetControl@lauinger-clan.de/prefs.js:262
+#: HeadsetControl@lauinger-clan.de/prefs.js:277
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:305
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:398
 msgid "Value for Off"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:254
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:305
+#: HeadsetControl@lauinger-clan.de/prefs.js:263
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:321
 msgid "Value for Low"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:255
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:321
+#: HeadsetControl@lauinger-clan.de/prefs.js:264
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:337
 msgid "Value for Medium"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:256
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:337
+#: HeadsetControl@lauinger-clan.de/prefs.js:265
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:353
 msgid "Value for High"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:257
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:353
+#: HeadsetControl@lauinger-clan.de/prefs.js:266
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:369
 msgid "Value for Maximum"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:269
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:398
+#: HeadsetControl@lauinger-clan.de/prefs.js:278
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:414
 msgid "Value 1"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:270
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:414
+#: HeadsetControl@lauinger-clan.de/prefs.js:279
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:430
 msgid "Value 2"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:271
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:430
+#: HeadsetControl@lauinger-clan.de/prefs.js:280
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:446
 msgid "Value 3"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:272
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:446
+#: HeadsetControl@lauinger-clan.de/prefs.js:281
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:462
 msgid "Value 4"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:273
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:462
+#: HeadsetControl@lauinger-clan.de/prefs.js:282
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:478
 msgid "Value 5"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:274
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:478
+#: HeadsetControl@lauinger-clan.de/prefs.js:283
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:494
 msgid "Value 6"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:275
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:494
+#: HeadsetControl@lauinger-clan.de/prefs.js:284
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:510
 msgid "Value 7"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:276
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:510
+#: HeadsetControl@lauinger-clan.de/prefs.js:285
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:526
 msgid "Value 8"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:277
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:526
+#: HeadsetControl@lauinger-clan.de/prefs.js:286
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:542
 msgid "Value 9"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:278
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:542
+#: HeadsetControl@lauinger-clan.de/prefs.js:287
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:558
 msgid "Value 10"
 msgstr ""
 
@@ -348,16 +348,16 @@ msgid "Passed to headsetcontrol to set the equalizer setting"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:63
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:235
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:236
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:251
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:252
 msgid "Equalizer options (equalizer might not be supported by your headset)"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:64
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:240
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:246
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:252
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:258
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:256
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:262
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:268
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:274
 msgid ""
 "Passed to headsetcontrol as parameter to equalizer option (when supported)"
 msgstr ""
@@ -372,16 +372,16 @@ msgid "Passed to headsetcontrol to set the equalizer preset"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:73
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:266
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:267
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:282
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:283
 msgid ""
 "Names of the equalizer presets (equalizer preset might not be supported by "
 "your headset)"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:75
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:271
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:272
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:287
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:288
 msgid "Shown in equalizer preset menu (when supported)"
 msgstr ""
 
@@ -400,8 +400,8 @@ msgid "Parameter to enable log outputs"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:85
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:190
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:191
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:206
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:207
 msgid "Enable / disable log outputs"
 msgstr ""
 
@@ -444,35 +444,35 @@ msgid "Makes battery percentage text colored/non-colored"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:110
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:206
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:222
 msgid "Color battery charge high"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:111
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:207
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:208
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:223
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:224
 msgid "The text color for battery charge 100% to 51%"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:115
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:213
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:229
 msgid "Color battery charge medium"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:116
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:214
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:215
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:230
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:231
 msgid "The text color for battery charge 50% to 26%"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:120
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:220
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:236
 msgid "Color battery charge low"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:121
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:221
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:222
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:237
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:238
 msgid "The text color for battery charge 25% to 0%"
 msgstr ""
 
@@ -500,6 +500,18 @@ msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:136
 msgid "Used for inactive time values (-1 disable)"
+msgstr ""
+
+#: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:140
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:190
+msgid "Battery percentage to trigger low battery notification"
+msgstr ""
+
+#: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:141
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:191
+msgid ""
+"When battery percentage falls below this value, a low battery notification "
+"will be triggered"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:9
@@ -571,7 +583,7 @@ msgid "Passed to headsetcontrol to set for voice prompts"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:104
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:231
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:247
 msgid "Equalizer"
 msgstr ""
 
@@ -602,12 +614,12 @@ msgid "Notification on low battery"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:144
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:189
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:205
 msgid "Use logging"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:145
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:201
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:217
 msgid "Use colors"
 msgstr ""
 
@@ -623,50 +635,53 @@ msgstr ""
 msgid "0 to disable"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:198
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:189
+msgid "Threshold for low battery notification (%)"
+msgstr ""
+
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:214
 msgid "Colors"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:202
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:203
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:218
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:219
 msgid "Enable / disable text colors"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:234
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:250
 msgid "Equalizer settings"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:265
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:281
 msgid "Equalizer presets"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:270
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:286
 msgid "Default"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:284
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:300
 msgid "Values for sidetone"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:285
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:286
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:301
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:302
 msgid "Off Low Medium High Maximum (-1 disable)"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:290
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:306
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:322
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:338
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:354
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:370
 msgid "Input for headsetcontrol sidetone command"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:291
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:307
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:323
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:339
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:355
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:384
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:371
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:400
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:416
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:432
@@ -677,23 +692,23 @@ msgstr ""
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:512
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:528
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:544
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:560
 msgid "-1 to disable"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:374
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:390
 msgid "Inactive Time"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:377
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:393
 msgid "Values for inactive time"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:378
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:379
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:394
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:395
 msgid "Values are used with parameter '-i' (-1 disable)"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:383
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:399
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:415
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:431
@@ -704,5 +719,6 @@ msgstr ""
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:511
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:527
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:543
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:559
 msgid "Input for headsetcontrol inactive time command"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-24 06:08+0200\n"
+"POT-Creation-Date: 2026-04-25 09:05+0200\n"
 "PO-Revision-Date: 2025-11-16 17:57+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -39,7 +39,7 @@ msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/extension.js:136
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:74
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:281
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:297
 msgid "Sidetone"
 msgstr ""
 
@@ -131,22 +131,22 @@ msgid " Minutes"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/extension.js:399
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:239
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:255
 msgid "Setting 1"
 msgstr "Nastavení 1"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:400
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:245
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:261
 msgid "Setting 2"
 msgstr "Nastavení 2"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:401
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:251
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:267
 msgid "Setting 3"
 msgstr "Nastavení 3"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:402
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:257
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:273
 msgid "Setting 4"
 msgstr "Nastavení 4"
 
@@ -168,84 +168,84 @@ msgid "Battery low! Please charge your headset."
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/prefs.js:22
-#: HeadsetControl@lauinger-clan.de/prefs.js:104
+#: HeadsetControl@lauinger-clan.de/prefs.js:109
 msgid "Select headsetcontrol executable"
 msgstr "Vyberte headsetcontrol spustitelný soubor"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:253
-#: HeadsetControl@lauinger-clan.de/prefs.js:268
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:289
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:382
+#: HeadsetControl@lauinger-clan.de/prefs.js:262
+#: HeadsetControl@lauinger-clan.de/prefs.js:277
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:305
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:398
 msgid "Value for Off"
 msgstr "Hodnota pro Vypnuto"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:254
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:305
+#: HeadsetControl@lauinger-clan.de/prefs.js:263
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:321
 msgid "Value for Low"
 msgstr "Hodnota pro Nzká"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:255
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:321
+#: HeadsetControl@lauinger-clan.de/prefs.js:264
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:337
 msgid "Value for Medium"
 msgstr "Hodnota pro Střední"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:256
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:337
+#: HeadsetControl@lauinger-clan.de/prefs.js:265
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:353
 msgid "Value for High"
 msgstr "Hodnota pro Vysoká"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:257
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:353
+#: HeadsetControl@lauinger-clan.de/prefs.js:266
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:369
 msgid "Value for Maximum"
 msgstr "Hodnota pro Maximální"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:269
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:398
+#: HeadsetControl@lauinger-clan.de/prefs.js:278
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:414
 msgid "Value 1"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:270
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:414
+#: HeadsetControl@lauinger-clan.de/prefs.js:279
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:430
 msgid "Value 2"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:271
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:430
+#: HeadsetControl@lauinger-clan.de/prefs.js:280
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:446
 msgid "Value 3"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:272
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:446
+#: HeadsetControl@lauinger-clan.de/prefs.js:281
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:462
 msgid "Value 4"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:273
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:462
+#: HeadsetControl@lauinger-clan.de/prefs.js:282
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:478
 msgid "Value 5"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:274
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:478
+#: HeadsetControl@lauinger-clan.de/prefs.js:283
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:494
 msgid "Value 6"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:275
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:494
+#: HeadsetControl@lauinger-clan.de/prefs.js:284
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:510
 msgid "Value 7"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:276
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:510
+#: HeadsetControl@lauinger-clan.de/prefs.js:285
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:526
 msgid "Value 8"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:277
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:526
+#: HeadsetControl@lauinger-clan.de/prefs.js:286
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:542
 msgid "Value 9"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:278
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:542
+#: HeadsetControl@lauinger-clan.de/prefs.js:287
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:558
 msgid "Value 10"
 msgstr ""
 
@@ -350,16 +350,16 @@ msgid "Passed to headsetcontrol to set the equalizer setting"
 msgstr "Předáno do headsetcontrol pro nastavení ekvalizéru"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:63
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:235
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:236
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:251
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:252
 msgid "Equalizer options (equalizer might not be supported by your headset)"
 msgstr "Možnosti ekvalizéru (ekvalizér nemusí být podporován vašimi sluchátky)"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:64
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:240
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:246
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:252
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:258
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:256
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:262
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:268
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:274
 msgid ""
 "Passed to headsetcontrol as parameter to equalizer option (when supported)"
 msgstr ""
@@ -376,8 +376,8 @@ msgid "Passed to headsetcontrol to set the equalizer preset"
 msgstr "Předáno do headsetcontrol pro nastavení přednastavení ekvalizéru"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:73
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:266
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:267
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:282
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:283
 msgid ""
 "Names of the equalizer presets (equalizer preset might not be supported by "
 "your headset)"
@@ -386,8 +386,8 @@ msgstr ""
 "podporována vašimi sluchátky)"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:75
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:271
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:272
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:287
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:288
 msgid "Shown in equalizer preset menu (when supported)"
 msgstr "Zobrazeno v nabídce přednastavení ekvalizéru (pokud je podporováno)"
 
@@ -406,8 +406,8 @@ msgid "Parameter to enable log outputs"
 msgstr "Parametr pro povolení logovacích výstupů"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:85
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:190
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:191
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:206
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:207
 msgid "Enable / disable log outputs"
 msgstr "Povolit / zakázat výstupy protokolu"
 
@@ -450,35 +450,35 @@ msgid "Makes battery percentage text colored/non-colored"
 msgstr "Barevný/černobílý text procenta baterie"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:110
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:206
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:222
 msgid "Color battery charge high"
 msgstr "Barva baterie při vysokém nabití"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:111
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:207
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:208
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:223
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:224
 msgid "The text color for battery charge 100% to 51%"
 msgstr "Barva textu při nabití baterie 100% až 51%"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:115
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:213
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:229
 msgid "Color battery charge medium"
 msgstr "Barva baterie při středním nabití"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:116
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:214
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:215
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:230
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:231
 msgid "The text color for battery charge 50% to 26%"
 msgstr "Barva textu při nabití baterie 50% až 26%"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:120
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:220
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:236
 msgid "Color battery charge low"
 msgstr "Barva baterie při nízkém nabití"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:121
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:221
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:222
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:237
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:238
 msgid "The text color for battery charge 25% to 0%"
 msgstr "Barva textu při nabití baterie 25% až 0%"
 
@@ -506,6 +506,18 @@ msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:136
 msgid "Used for inactive time values (-1 disable)"
+msgstr ""
+
+#: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:140
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:190
+msgid "Battery percentage to trigger low battery notification"
+msgstr ""
+
+#: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:141
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:191
+msgid ""
+"When battery percentage falls below this value, a low battery notification "
+"will be triggered"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:9
@@ -577,7 +589,7 @@ msgid "Passed to headsetcontrol to set for voice prompts"
 msgstr "Předáno do headsetcontrol pro nastavení hlasových pokynů"
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:104
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:231
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:247
 msgid "Equalizer"
 msgstr "Ekvalizér"
 
@@ -608,12 +620,12 @@ msgid "Notification on low battery"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:144
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:189
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:205
 msgid "Use logging"
 msgstr "Použít protokoly"
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:145
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:201
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:217
 msgid "Use colors"
 msgstr "Použít barvy"
 
@@ -629,50 +641,53 @@ msgstr ""
 msgid "0 to disable"
 msgstr "0 pro zakázání"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:198
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:189
+msgid "Threshold for low battery notification (%)"
+msgstr ""
+
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:214
 msgid "Colors"
 msgstr "Barvy"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:202
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:203
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:218
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:219
 msgid "Enable / disable text colors"
 msgstr "Povolit / zakázat barvy textu"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:234
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:250
 msgid "Equalizer settings"
 msgstr "Nastavení ekvalizéru"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:265
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:281
 msgid "Equalizer presets"
 msgstr "Přednastavení ekvalizéru"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:270
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:286
 msgid "Default"
 msgstr "Výchozí"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:284
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:300
 msgid "Values for sidetone"
 msgstr "Hodnoty pro sidetone"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:285
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:286
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:301
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:302
 msgid "Off Low Medium High Maximum (-1 disable)"
 msgstr "Vypnuto Nízká Střední Vysoká Maximální (-1 zakázat)"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:290
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:306
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:322
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:338
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:354
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:370
 msgid "Input for headsetcontrol sidetone command"
 msgstr "Vstup pro příkaz sidetone ovládání sluchátek"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:291
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:307
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:323
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:339
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:355
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:384
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:371
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:400
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:416
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:432
@@ -683,23 +698,23 @@ msgstr "Vstup pro příkaz sidetone ovládání sluchátek"
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:512
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:528
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:544
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:560
 msgid "-1 to disable"
 msgstr "-1 pro zakázání"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:374
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:390
 msgid "Inactive Time"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:377
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:393
 msgid "Values for inactive time"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:378
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:379
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:394
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:395
 msgid "Values are used with parameter '-i' (-1 disable)"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:383
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:399
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:415
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:431
@@ -710,5 +725,6 @@ msgstr ""
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:511
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:527
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:543
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:559
 msgid "Input for headsetcontrol inactive time command"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-24 06:08+0200\n"
-"PO-Revision-Date: 2026-01-31 12:22+0100\n"
+"POT-Creation-Date: 2026-04-25 09:05+0200\n"
+"PO-Revision-Date: 2026-04-25 09:05+0200\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
 "Language: de\n"
@@ -40,7 +40,7 @@ msgstr "Chat-Mix"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:136
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:74
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:281
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:297
 msgid "Sidetone"
 msgstr "Mithörton"
 
@@ -132,22 +132,22 @@ msgid " Minutes"
 msgstr " Minuten"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:399
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:239
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:255
 msgid "Setting 1"
 msgstr "Einstellung 1"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:400
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:245
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:261
 msgid "Setting 2"
 msgstr "Einstellung 2"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:401
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:251
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:267
 msgid "Setting 3"
 msgstr "Einstellung 3"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:402
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:257
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:273
 msgid "Setting 4"
 msgstr "Einstellung 4"
 
@@ -169,84 +169,84 @@ msgid "Battery low! Please charge your headset."
 msgstr "Batterie schwach! Bitte laden Sie Ihr Headset auf."
 
 #: HeadsetControl@lauinger-clan.de/prefs.js:22
-#: HeadsetControl@lauinger-clan.de/prefs.js:104
+#: HeadsetControl@lauinger-clan.de/prefs.js:109
 msgid "Select headsetcontrol executable"
 msgstr "Wählen Sie die headsetcontrol ausführbare Datei"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:253
-#: HeadsetControl@lauinger-clan.de/prefs.js:268
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:289
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:382
+#: HeadsetControl@lauinger-clan.de/prefs.js:262
+#: HeadsetControl@lauinger-clan.de/prefs.js:277
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:305
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:398
 msgid "Value for Off"
 msgstr "Wert für Aus"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:254
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:305
+#: HeadsetControl@lauinger-clan.de/prefs.js:263
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:321
 msgid "Value for Low"
 msgstr "Wert für Leise"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:255
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:321
+#: HeadsetControl@lauinger-clan.de/prefs.js:264
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:337
 msgid "Value for Medium"
 msgstr "Wert für Mittel"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:256
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:337
+#: HeadsetControl@lauinger-clan.de/prefs.js:265
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:353
 msgid "Value for High"
 msgstr "Wert für Hoch"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:257
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:353
+#: HeadsetControl@lauinger-clan.de/prefs.js:266
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:369
 msgid "Value for Maximum"
 msgstr "Wert für Maximum"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:269
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:398
+#: HeadsetControl@lauinger-clan.de/prefs.js:278
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:414
 msgid "Value 1"
 msgstr "Wert 1"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:270
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:414
+#: HeadsetControl@lauinger-clan.de/prefs.js:279
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:430
 msgid "Value 2"
 msgstr "Wert 2"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:271
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:430
+#: HeadsetControl@lauinger-clan.de/prefs.js:280
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:446
 msgid "Value 3"
 msgstr "Wert 3"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:272
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:446
+#: HeadsetControl@lauinger-clan.de/prefs.js:281
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:462
 msgid "Value 4"
 msgstr "Wert 4"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:273
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:462
+#: HeadsetControl@lauinger-clan.de/prefs.js:282
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:478
 msgid "Value 5"
 msgstr "Wert 5"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:274
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:478
+#: HeadsetControl@lauinger-clan.de/prefs.js:283
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:494
 msgid "Value 6"
 msgstr "Wert 6"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:275
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:494
+#: HeadsetControl@lauinger-clan.de/prefs.js:284
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:510
 msgid "Value 7"
 msgstr "Wert 7"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:276
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:510
+#: HeadsetControl@lauinger-clan.de/prefs.js:285
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:526
 msgid "Value 8"
 msgstr "Wert 8"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:277
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:526
+#: HeadsetControl@lauinger-clan.de/prefs.js:286
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:542
 msgid "Value 9"
 msgstr "Wert 9"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:278
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:542
+#: HeadsetControl@lauinger-clan.de/prefs.js:287
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:558
 msgid "Value 10"
 msgstr "Wert 10"
 
@@ -351,17 +351,17 @@ msgid "Passed to headsetcontrol to set the equalizer setting"
 msgstr "Übergabe an headsetcontrol zum Setzen des Equalizers"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:63
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:235
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:236
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:251
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:252
 msgid "Equalizer options (equalizer might not be supported by your headset)"
 msgstr ""
 "Equalizeroptionen (Equalizer könnte von Ihrem Headset nicht unterstützt sein)"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:64
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:240
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:246
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:252
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:258
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:256
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:262
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:268
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:274
 msgid ""
 "Passed to headsetcontrol as parameter to equalizer option (when supported)"
 msgstr ""
@@ -378,8 +378,8 @@ msgid "Passed to headsetcontrol to set the equalizer preset"
 msgstr "Übergabe an headsetcontrol zum Setzen der Equalizer-Voreinstellung"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:73
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:266
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:267
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:282
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:283
 msgid ""
 "Names of the equalizer presets (equalizer preset might not be supported by "
 "your headset)"
@@ -388,8 +388,8 @@ msgstr ""
 "Ihrem Headset nicht unterstützt sein)"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:75
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:271
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:272
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:287
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:288
 msgid "Shown in equalizer preset menu (when supported)"
 msgstr "Werden im Equalizer-Voreinstellungsmenü angezeigt (wenn unterstützt)"
 
@@ -409,8 +409,8 @@ msgid "Parameter to enable log outputs"
 msgstr "Parameter zum Erlauben von Protokollausgaben"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:85
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:190
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:191
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:206
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:207
 msgid "Enable / disable log outputs"
 msgstr "Erlaube / verbiete Protokollausgaben"
 
@@ -456,35 +456,35 @@ msgid "Makes battery percentage text colored/non-colored"
 msgstr "Farblicher Kennzeichnung der Batterieladungsanzeige umschalten"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:110
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:206
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:222
 msgid "Color battery charge high"
 msgstr "Farbe hohe Batterieladung"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:111
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:207
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:208
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:223
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:224
 msgid "The text color for battery charge 100% to 51%"
 msgstr "Textfarbe für Batterieladung 100% bis 51%"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:115
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:213
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:229
 msgid "Color battery charge medium"
 msgstr "Farbe mittlere Batterieladung"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:116
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:214
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:215
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:230
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:231
 msgid "The text color for battery charge 50% to 26%"
 msgstr "Textfarbe für Batterieladung 50% bis 26%"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:120
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:220
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:236
 msgid "Color battery charge low"
 msgstr "Farbe niedrige Batterieladung"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:121
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:221
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:222
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:237
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:238
 msgid "The text color for battery charge 25% to 0%"
 msgstr "Textfarbe für Batterieladung 25% bis 0%"
 
@@ -515,6 +515,22 @@ msgstr "Inaktivitätszeit Werte"
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:136
 msgid "Used for inactive time values (-1 disable)"
 msgstr "Verwendet als Inaktivitätszeit-Werte (-1 zum Deaktivieren)"
+
+#: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:140
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:190
+msgid "Battery percentage to trigger low battery notification"
+msgstr ""
+"Akkustand in Prozent, bei dem eine Warnmeldung wegen niedrigem Akkustand "
+"ausgelöst wird"
+
+#: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:141
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:191
+msgid ""
+"When battery percentage falls below this value, a low battery notification "
+"will be triggered"
+msgstr ""
+"Wenn der Akkustand unter diesen Wert fällt, wird eine Benachrichtigung über "
+"den niedrigen Akkustand ausgelöst"
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:9
 msgid "Global"
@@ -585,7 +601,7 @@ msgid "Passed to headsetcontrol to set for voice prompts"
 msgstr "Parameter zum Setzen der Sprachausgabe"
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:104
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:231
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:247
 msgid "Equalizer"
 msgstr "Equalizer"
 
@@ -616,12 +632,12 @@ msgid "Notification on low battery"
 msgstr "Benachrichtigung bei niedrigem Batteriestand"
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:144
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:189
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:205
 msgid "Use logging"
 msgstr "Protokoll verwenden"
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:145
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:201
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:217
 msgid "Use colors"
 msgstr "Farben verwenden"
 
@@ -637,50 +653,53 @@ msgstr "Aktualisierungsinterval (Minuten)"
 msgid "0 to disable"
 msgstr "0 zum Deaktivieren"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:198
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:189
+msgid "Threshold for low battery notification (%)"
+msgstr "Schwellenwert für die Benachrichtigung bei niedrigem Akkustand (%)"
+
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:214
 msgid "Colors"
 msgstr "Farben"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:202
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:203
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:218
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:219
 msgid "Enable / disable text colors"
 msgstr "Erlaube / verbiete Textfarben"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:234
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:250
 msgid "Equalizer settings"
 msgstr "Equalizer-Einstellungen"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:265
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:281
 msgid "Equalizer presets"
 msgstr "Equalizer-Voreinstellungen"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:270
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:286
 msgid "Default"
 msgstr "Standard"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:284
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:300
 msgid "Values for sidetone"
 msgstr "Werte für Mithörton"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:285
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:286
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:301
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:302
 msgid "Off Low Medium High Maximum (-1 disable)"
 msgstr "Aus Leise Mittel Hoch Maximum (-1 zum Deaktivieren)"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:290
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:306
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:322
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:338
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:354
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:370
 msgid "Input for headsetcontrol sidetone command"
 msgstr "Eingabe für headsetcontrol Mithörton Kommando"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:291
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:307
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:323
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:339
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:355
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:384
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:371
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:400
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:416
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:432
@@ -691,23 +710,23 @@ msgstr "Eingabe für headsetcontrol Mithörton Kommando"
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:512
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:528
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:544
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:560
 msgid "-1 to disable"
 msgstr "-1 zum Deaktivieren"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:374
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:390
 msgid "Inactive Time"
 msgstr "Inaktivitätszeit"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:377
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:393
 msgid "Values for inactive time"
 msgstr "Werte für Inaktivitätszeit"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:378
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:379
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:394
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:395
 msgid "Values are used with parameter '-i' (-1 disable)"
 msgstr "Werte werden mit dem Parameter '-i' verwendet (-1 zum Deaktivieren)"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:383
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:399
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:415
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:431
@@ -718,5 +737,6 @@ msgstr "Werte werden mit dem Parameter '-i' verwendet (-1 zum Deaktivieren)"
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:511
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:527
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:543
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:559
 msgid "Input for headsetcontrol inactive time command"
 msgstr "Übergabe an headsetcontrol zum Setzen der Inaktivitätszeit"

--- a/po/es.po
+++ b/po/es.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-24 06:08+0200\n"
+"POT-Creation-Date: 2026-04-25 09:05+0200\n"
 "PO-Revision-Date: 2026-03-05 17:22+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -40,7 +40,7 @@ msgstr "Chat-Mix"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:136
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:74
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:281
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:297
 msgid "Sidetone"
 msgstr "Sidetone"
 
@@ -132,22 +132,22 @@ msgid " Minutes"
 msgstr " Minutos"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:399
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:239
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:255
 msgid "Setting 1"
 msgstr "Configuracion 1"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:400
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:245
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:261
 msgid "Setting 2"
 msgstr "Configuracion 2"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:401
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:251
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:267
 msgid "Setting 3"
 msgstr "Configuracion 3"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:402
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:257
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:273
 msgid "Setting 4"
 msgstr "Configuracion 4"
 
@@ -170,84 +170,84 @@ msgid "Battery low! Please charge your headset."
 msgstr "¡Batería baja! Por favor, cargue sus auriculares."
 
 #: HeadsetControl@lauinger-clan.de/prefs.js:22
-#: HeadsetControl@lauinger-clan.de/prefs.js:104
+#: HeadsetControl@lauinger-clan.de/prefs.js:109
 msgid "Select headsetcontrol executable"
 msgstr "Seleccione el ejecutable de control de auriculares"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:253
-#: HeadsetControl@lauinger-clan.de/prefs.js:268
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:289
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:382
+#: HeadsetControl@lauinger-clan.de/prefs.js:262
+#: HeadsetControl@lauinger-clan.de/prefs.js:277
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:305
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:398
 msgid "Value for Off"
 msgstr "Valor para Apagado"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:254
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:305
+#: HeadsetControl@lauinger-clan.de/prefs.js:263
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:321
 msgid "Value for Low"
 msgstr "Valor para Bajo"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:255
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:321
+#: HeadsetControl@lauinger-clan.de/prefs.js:264
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:337
 msgid "Value for Medium"
 msgstr "Valor para Medio"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:256
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:337
+#: HeadsetControl@lauinger-clan.de/prefs.js:265
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:353
 msgid "Value for High"
 msgstr "Valor para Alto"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:257
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:353
+#: HeadsetControl@lauinger-clan.de/prefs.js:266
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:369
 msgid "Value for Maximum"
 msgstr "Valor para Máximo"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:269
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:398
+#: HeadsetControl@lauinger-clan.de/prefs.js:278
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:414
 msgid "Value 1"
 msgstr "Valor 1"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:270
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:414
+#: HeadsetControl@lauinger-clan.de/prefs.js:279
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:430
 msgid "Value 2"
 msgstr "Valor 2"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:271
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:430
+#: HeadsetControl@lauinger-clan.de/prefs.js:280
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:446
 msgid "Value 3"
 msgstr "Valor 3"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:272
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:446
+#: HeadsetControl@lauinger-clan.de/prefs.js:281
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:462
 msgid "Value 4"
 msgstr "Valor 4"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:273
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:462
+#: HeadsetControl@lauinger-clan.de/prefs.js:282
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:478
 msgid "Value 5"
 msgstr "Valor 5"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:274
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:478
+#: HeadsetControl@lauinger-clan.de/prefs.js:283
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:494
 msgid "Value 6"
 msgstr "Valor 6"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:275
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:494
+#: HeadsetControl@lauinger-clan.de/prefs.js:284
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:510
 msgid "Value 7"
 msgstr "Valor 7"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:276
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:510
+#: HeadsetControl@lauinger-clan.de/prefs.js:285
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:526
 msgid "Value 8"
 msgstr "Valor 8"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:277
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:526
+#: HeadsetControl@lauinger-clan.de/prefs.js:286
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:542
 msgid "Value 9"
 msgstr "Valor 9"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:278
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:542
+#: HeadsetControl@lauinger-clan.de/prefs.js:287
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:558
 msgid "Value 10"
 msgstr "Valor 10"
 
@@ -353,18 +353,18 @@ msgstr ""
 "Pasado a headsetcontrol para configurar la configuración del ecualizador"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:63
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:235
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:236
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:251
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:252
 msgid "Equalizer options (equalizer might not be supported by your headset)"
 msgstr ""
 "Opciones de ecualizador (el ecualizador podría no ser compatible con sus "
 "auriculares)"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:64
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:240
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:246
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:252
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:258
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:256
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:262
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:268
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:274
 msgid ""
 "Passed to headsetcontrol as parameter to equalizer option (when supported)"
 msgstr ""
@@ -381,8 +381,8 @@ msgid "Passed to headsetcontrol to set the equalizer preset"
 msgstr "Pasado a headsetcontrol para configurar el preajuste del ecualizador"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:73
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:266
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:267
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:282
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:283
 msgid ""
 "Names of the equalizer presets (equalizer preset might not be supported by "
 "your headset)"
@@ -391,8 +391,8 @@ msgstr ""
 "podría no ser compatible con sus auriculares)"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:75
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:271
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:272
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:287
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:288
 msgid "Shown in equalizer preset menu (when supported)"
 msgstr ""
 "Mostrado en el menú de preajustes del ecualizador (cuando sea compatible)"
@@ -412,8 +412,8 @@ msgid "Parameter to enable log outputs"
 msgstr "Parámetro para habilitar salidas de registro"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:85
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:190
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:191
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:206
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:207
 msgid "Enable / disable log outputs"
 msgstr "Habilitar / deshabilitar salidas de registro"
 
@@ -460,35 +460,35 @@ msgid "Makes battery percentage text colored/non-colored"
 msgstr "Hace que el texto del porcentaje de batería sea colorido/no colorido"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:110
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:206
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:222
 msgid "Color battery charge high"
 msgstr "Color de carga de batería alta"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:111
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:207
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:208
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:223
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:224
 msgid "The text color for battery charge 100% to 51%"
 msgstr "El color del texto para la carga de batería del 100% al 51%"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:115
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:213
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:229
 msgid "Color battery charge medium"
 msgstr "Color de carga de batería media"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:116
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:214
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:215
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:230
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:231
 msgid "The text color for battery charge 50% to 26%"
 msgstr "El color del texto para la carga de batería del 50% al 26%"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:120
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:220
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:236
 msgid "Color battery charge low"
 msgstr "Color de carga de batería baja"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:121
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:221
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:222
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:237
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:238
 msgid "The text color for battery charge 25% to 0%"
 msgstr "El color del texto para la carga de batería del 25% al 0%"
 
@@ -518,6 +518,18 @@ msgstr "Valores de tiempo inactivo"
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:136
 msgid "Used for inactive time values (-1 disable)"
 msgstr "Usado para valores de tiempo inactivo (-1 deshabilitar)"
+
+#: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:140
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:190
+msgid "Battery percentage to trigger low battery notification"
+msgstr ""
+
+#: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:141
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:191
+msgid ""
+"When battery percentage falls below this value, a low battery notification "
+"will be triggered"
+msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:9
 msgid "Global"
@@ -589,7 +601,7 @@ msgid "Passed to headsetcontrol to set for voice prompts"
 msgstr "Pasado a headsetcontrol para configurar indicaciones de voz"
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:104
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:231
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:247
 msgid "Equalizer"
 msgstr "Ecualizador"
 
@@ -620,12 +632,12 @@ msgid "Notification on low battery"
 msgstr "Notificación por batería baja"
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:144
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:189
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:205
 msgid "Use logging"
 msgstr "Usar registros"
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:145
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:201
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:217
 msgid "Use colors"
 msgstr "Usar colores"
 
@@ -641,50 +653,53 @@ msgstr "Intervalo de actualización (minutos)"
 msgid "0 to disable"
 msgstr "0 para deshabilitar"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:198
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:189
+msgid "Threshold for low battery notification (%)"
+msgstr ""
+
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:214
 msgid "Colors"
 msgstr "Colores"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:202
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:203
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:218
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:219
 msgid "Enable / disable text colors"
 msgstr "Habilitar / deshabilitar colores de texto"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:234
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:250
 msgid "Equalizer settings"
 msgstr "Configuraciones del ecualizador"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:265
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:281
 msgid "Equalizer presets"
 msgstr "Preajustes del ecualizador"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:270
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:286
 msgid "Default"
 msgstr "Predeterminado"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:284
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:300
 msgid "Values for sidetone"
 msgstr "Valores para sidetone"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:285
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:286
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:301
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:302
 msgid "Off Low Medium High Maximum (-1 disable)"
 msgstr "Apagado Bajo Medio Alto Máximo (-1 deshabilitar)"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:290
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:306
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:322
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:338
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:354
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:370
 msgid "Input for headsetcontrol sidetone command"
 msgstr "Entrada para el comando sidetone de control de auriculares"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:291
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:307
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:323
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:339
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:355
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:384
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:371
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:400
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:416
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:432
@@ -695,23 +710,23 @@ msgstr "Entrada para el comando sidetone de control de auriculares"
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:512
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:528
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:544
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:560
 msgid "-1 to disable"
 msgstr "-1 para deshabilitar"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:374
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:390
 msgid "Inactive Time"
 msgstr "Tiempo inactivo"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:377
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:393
 msgid "Values for inactive time"
 msgstr "Valores para tiempo inactivo"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:378
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:379
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:394
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:395
 msgid "Values are used with parameter '-i' (-1 disable)"
 msgstr "Los valores se usan con el parámetro '-i' (-1 deshabilitar)"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:383
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:399
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:415
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:431
@@ -722,5 +737,6 @@ msgstr "Los valores se usan con el parámetro '-i' (-1 deshabilitar)"
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:511
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:527
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:543
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:559
 msgid "Input for headsetcontrol inactive time command"
 msgstr "Entrada para el comando de tiempo inactivo de control de auriculares"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-24 06:08+0200\n"
+"POT-Creation-Date: 2026-04-25 09:05+0200\n"
 "PO-Revision-Date: 2026-01-29 21:56+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -40,7 +40,7 @@ msgstr "Chat-Mix"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:136
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:74
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:281
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:297
 msgid "Sidetone"
 msgstr "Niveau retour micro"
 
@@ -132,22 +132,22 @@ msgid " Minutes"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/extension.js:399
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:239
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:255
 msgid "Setting 1"
 msgstr "Paramètre 1"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:400
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:245
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:261
 msgid "Setting 2"
 msgstr "Paramètre 2"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:401
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:251
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:267
 msgid "Setting 3"
 msgstr "Paramètre 3"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:402
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:257
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:273
 msgid "Setting 4"
 msgstr "Paramètre 4"
 
@@ -170,84 +170,84 @@ msgid "Battery low! Please charge your headset."
 msgstr "Batterie faible ! Veuillez recharger votre casque."
 
 #: HeadsetControl@lauinger-clan.de/prefs.js:22
-#: HeadsetControl@lauinger-clan.de/prefs.js:104
+#: HeadsetControl@lauinger-clan.de/prefs.js:109
 msgid "Select headsetcontrol executable"
 msgstr "Selectioner l'exécutable headsetcontrol"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:253
-#: HeadsetControl@lauinger-clan.de/prefs.js:268
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:289
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:382
+#: HeadsetControl@lauinger-clan.de/prefs.js:262
+#: HeadsetControl@lauinger-clan.de/prefs.js:277
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:305
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:398
 msgid "Value for Off"
 msgstr "Valeur pour Désactivé"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:254
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:305
+#: HeadsetControl@lauinger-clan.de/prefs.js:263
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:321
 msgid "Value for Low"
 msgstr "Valeur pour Bas"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:255
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:321
+#: HeadsetControl@lauinger-clan.de/prefs.js:264
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:337
 msgid "Value for Medium"
 msgstr "Valeur pour Moyen"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:256
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:337
+#: HeadsetControl@lauinger-clan.de/prefs.js:265
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:353
 msgid "Value for High"
 msgstr "Valeur pour Haut"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:257
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:353
+#: HeadsetControl@lauinger-clan.de/prefs.js:266
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:369
 msgid "Value for Maximum"
 msgstr "Valeur pour Maximum"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:269
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:398
+#: HeadsetControl@lauinger-clan.de/prefs.js:278
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:414
 msgid "Value 1"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:270
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:414
+#: HeadsetControl@lauinger-clan.de/prefs.js:279
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:430
 msgid "Value 2"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:271
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:430
+#: HeadsetControl@lauinger-clan.de/prefs.js:280
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:446
 msgid "Value 3"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:272
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:446
+#: HeadsetControl@lauinger-clan.de/prefs.js:281
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:462
 msgid "Value 4"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:273
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:462
+#: HeadsetControl@lauinger-clan.de/prefs.js:282
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:478
 msgid "Value 5"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:274
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:478
+#: HeadsetControl@lauinger-clan.de/prefs.js:283
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:494
 msgid "Value 6"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:275
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:494
+#: HeadsetControl@lauinger-clan.de/prefs.js:284
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:510
 msgid "Value 7"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:276
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:510
+#: HeadsetControl@lauinger-clan.de/prefs.js:285
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:526
 msgid "Value 8"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:277
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:526
+#: HeadsetControl@lauinger-clan.de/prefs.js:286
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:542
 msgid "Value 9"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:278
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:542
+#: HeadsetControl@lauinger-clan.de/prefs.js:287
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:558
 msgid "Value 10"
 msgstr ""
 
@@ -357,18 +357,18 @@ msgstr ""
 "Transmis au contrôle du casque pour définir les réglages de l'égaliseur"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:63
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:235
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:236
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:251
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:252
 msgid "Equalizer options (equalizer might not be supported by your headset)"
 msgstr ""
 "Options de l'égaliseur (l'égaliseur pourrait ne pas être pris en charge par "
 "votre casque)"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:64
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:240
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:246
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:252
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:258
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:256
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:262
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:268
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:274
 msgid ""
 "Passed to headsetcontrol as parameter to equalizer option (when supported)"
 msgstr ""
@@ -387,8 +387,8 @@ msgstr ""
 "Transmis au contrôle du casque pour définir le préréglage de l'égaliseur"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:73
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:266
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:267
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:282
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:283
 msgid ""
 "Names of the equalizer presets (equalizer preset might not be supported by "
 "your headset)"
@@ -397,8 +397,8 @@ msgstr ""
 "pourraient ne pas être pris en charge par votre casque)"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:75
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:271
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:272
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:287
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:288
 msgid "Shown in equalizer preset menu (when supported)"
 msgstr ""
 "Affiché dans le menu des préréglages de l'égaliseur (lorsqu'il est pris en "
@@ -420,8 +420,8 @@ msgid "Parameter to enable log outputs"
 msgstr "Paramètre pour activer les sortie du journal"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:85
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:190
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:191
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:206
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:207
 msgid "Enable / disable log outputs"
 msgstr "Activer / Désactiver les sortie du journal"
 
@@ -469,35 +469,35 @@ msgid "Makes battery percentage text colored/non-colored"
 msgstr "Colorise / Décolorise le texte de pourcentage de batterie"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:110
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:206
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:222
 msgid "Color battery charge high"
 msgstr "Couleur de charge élevé de la batterie"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:111
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:207
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:208
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:223
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:224
 msgid "The text color for battery charge 100% to 51%"
 msgstr "Couleur de texte pour charge de batterie de 100% à 51%"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:115
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:213
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:229
 msgid "Color battery charge medium"
 msgstr "Couleur de charge moyenne de la batterie"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:116
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:214
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:215
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:230
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:231
 msgid "The text color for battery charge 50% to 26%"
 msgstr "Couleur de texte pour charge de batterie de 50% à 26%"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:120
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:220
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:236
 msgid "Color battery charge low"
 msgstr "Couleur de charge faible de la batterie"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:121
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:221
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:222
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:237
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:238
 msgid "The text color for battery charge 25% to 0%"
 msgstr "Couleur de texte pour charge de batterie de 25% à 0%"
 
@@ -525,6 +525,18 @@ msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:136
 msgid "Used for inactive time values (-1 disable)"
+msgstr ""
+
+#: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:140
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:190
+msgid "Battery percentage to trigger low battery notification"
+msgstr ""
+
+#: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:141
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:191
+msgid ""
+"When battery percentage falls below this value, a low battery notification "
+"will be triggered"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:9
@@ -597,7 +609,7 @@ msgstr ""
 "Transmis au contrôle du casque pour controller les instructions vocales"
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:104
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:231
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:247
 msgid "Equalizer"
 msgstr "L'égaliseur"
 
@@ -628,12 +640,12 @@ msgid "Notification on low battery"
 msgstr "Notification de batterie faible"
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:144
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:189
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:205
 msgid "Use logging"
 msgstr "Utiliser le journal"
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:145
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:201
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:217
 msgid "Use colors"
 msgstr "Utiliser les couleurs"
 
@@ -649,50 +661,53 @@ msgstr "Intervalle de rafraîchissement (minutes)"
 msgid "0 to disable"
 msgstr "0 pour désactiver"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:198
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:189
+msgid "Threshold for low battery notification (%)"
+msgstr ""
+
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:214
 msgid "Colors"
 msgstr "Couleurs"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:202
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:203
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:218
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:219
 msgid "Enable / disable text colors"
 msgstr "Activer / Désactiver les couleurs de texte"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:234
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:250
 msgid "Equalizer settings"
 msgstr "Paramètres de l'égaliseur"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:265
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:281
 msgid "Equalizer presets"
 msgstr "Préréglages égaliseur"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:270
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:286
 msgid "Default"
 msgstr "Par défaut"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:284
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:300
 msgid "Values for sidetone"
 msgstr "Valeurs pour le ton côté"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:285
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:286
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:301
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:302
 msgid "Off Low Medium High Maximum (-1 disable)"
 msgstr "Désactivé Bas Moyen Haut Maximum (-1 désactiver)"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:290
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:306
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:322
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:338
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:354
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:370
 msgid "Input for headsetcontrol sidetone command"
 msgstr "Entrée pour la commande de ton côté du contrôle du casque"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:291
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:307
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:323
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:339
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:355
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:384
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:371
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:400
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:416
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:432
@@ -703,23 +718,23 @@ msgstr "Entrée pour la commande de ton côté du contrôle du casque"
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:512
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:528
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:544
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:560
 msgid "-1 to disable"
 msgstr "-1 pour désactiver"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:374
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:390
 msgid "Inactive Time"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:377
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:393
 msgid "Values for inactive time"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:378
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:379
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:394
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:395
 msgid "Values are used with parameter '-i' (-1 disable)"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:383
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:399
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:415
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:431
@@ -730,5 +745,6 @@ msgstr ""
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:511
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:527
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:543
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:559
 msgid "Input for headsetcontrol inactive time command"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-24 06:08+0200\n"
+"POT-Creation-Date: 2026-04-25 09:05+0200\n"
 "PO-Revision-Date: 2026-01-13 21:26+0100\n"
 "Last-Translator: ALbano Battistella <albanobattistella@gmail.com>\n"
 "Language-Team: Italian <LL@li.org>\n"
@@ -39,7 +39,7 @@ msgstr "Chat-Mix"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:136
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:74
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:281
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:297
 msgid "Sidetone"
 msgstr "Tono laterale"
 
@@ -131,22 +131,22 @@ msgid " Minutes"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/extension.js:399
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:239
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:255
 msgid "Setting 1"
 msgstr "Impostazione 1"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:400
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:245
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:261
 msgid "Setting 2"
 msgstr "Impostazione 2"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:401
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:251
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:267
 msgid "Setting 3"
 msgstr "Impostazione 3"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:402
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:257
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:273
 msgid "Setting 4"
 msgstr "Impostazione 4"
 
@@ -169,84 +169,84 @@ msgid "Battery low! Please charge your headset."
 msgstr "Batteria scarica! Ricaricare le cuffie."
 
 #: HeadsetControl@lauinger-clan.de/prefs.js:22
-#: HeadsetControl@lauinger-clan.de/prefs.js:104
+#: HeadsetControl@lauinger-clan.de/prefs.js:109
 msgid "Select headsetcontrol executable"
 msgstr "Selezionare l'eseguibile del controllo dell'auricolare"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:253
-#: HeadsetControl@lauinger-clan.de/prefs.js:268
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:289
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:382
+#: HeadsetControl@lauinger-clan.de/prefs.js:262
+#: HeadsetControl@lauinger-clan.de/prefs.js:277
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:305
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:398
 msgid "Value for Off"
 msgstr "Valore per Off"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:254
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:305
+#: HeadsetControl@lauinger-clan.de/prefs.js:263
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:321
 msgid "Value for Low"
 msgstr "Valore per Bassa"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:255
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:321
+#: HeadsetControl@lauinger-clan.de/prefs.js:264
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:337
 msgid "Value for Medium"
 msgstr "Valore per Media"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:256
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:337
+#: HeadsetControl@lauinger-clan.de/prefs.js:265
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:353
 msgid "Value for High"
 msgstr "Valore per Alta"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:257
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:353
+#: HeadsetControl@lauinger-clan.de/prefs.js:266
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:369
 msgid "Value for Maximum"
 msgstr "Valore per Massimo"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:269
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:398
+#: HeadsetControl@lauinger-clan.de/prefs.js:278
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:414
 msgid "Value 1"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:270
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:414
+#: HeadsetControl@lauinger-clan.de/prefs.js:279
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:430
 msgid "Value 2"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:271
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:430
+#: HeadsetControl@lauinger-clan.de/prefs.js:280
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:446
 msgid "Value 3"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:272
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:446
+#: HeadsetControl@lauinger-clan.de/prefs.js:281
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:462
 msgid "Value 4"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:273
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:462
+#: HeadsetControl@lauinger-clan.de/prefs.js:282
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:478
 msgid "Value 5"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:274
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:478
+#: HeadsetControl@lauinger-clan.de/prefs.js:283
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:494
 msgid "Value 6"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:275
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:494
+#: HeadsetControl@lauinger-clan.de/prefs.js:284
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:510
 msgid "Value 7"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:276
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:510
+#: HeadsetControl@lauinger-clan.de/prefs.js:285
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:526
 msgid "Value 8"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:277
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:526
+#: HeadsetControl@lauinger-clan.de/prefs.js:286
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:542
 msgid "Value 9"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:278
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:542
+#: HeadsetControl@lauinger-clan.de/prefs.js:287
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:558
 msgid "Value 10"
 msgstr ""
 
@@ -355,17 +355,17 @@ msgstr ""
 "dell'equalizzatore"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:63
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:235
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:236
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:251
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:252
 msgid "Equalizer options (equalizer might not be supported by your headset)"
 msgstr ""
 "Opzioni dell'equalizzatore (potrebbe non essere supportato dalle tue cuffie)"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:64
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:240
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:246
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:252
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:258
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:256
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:262
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:268
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:274
 msgid ""
 "Passed to headsetcontrol as parameter to equalizer option (when supported)"
 msgstr ""
@@ -386,8 +386,8 @@ msgstr ""
 "dell'equalizzatore"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:73
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:266
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:267
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:282
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:283
 msgid ""
 "Names of the equalizer presets (equalizer preset might not be supported by "
 "your headset)"
@@ -396,8 +396,8 @@ msgstr ""
 "supportato dalle tue cuffie)"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:75
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:271
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:272
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:287
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:288
 msgid "Shown in equalizer preset menu (when supported)"
 msgstr ""
 "Mostrato nel menu delle preimpostazioni dell'equalizzatore (quando "
@@ -418,8 +418,8 @@ msgid "Parameter to enable log outputs"
 msgstr "Parametro per abilitare output log"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:85
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:190
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:191
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:206
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:207
 msgid "Enable / disable log outputs"
 msgstr "Abilita / disabilita log output"
 
@@ -467,35 +467,35 @@ msgid "Makes battery percentage text colored/non-colored"
 msgstr "Rende il testo della percentuale della batteria colorato/non colorato"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:110
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:206
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:222
 msgid "Color battery charge high"
 msgstr "Colore batteria carica alta"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:111
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:207
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:208
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:223
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:224
 msgid "The text color for battery charge 100% to 51%"
 msgstr "Il colore del testo per la carica della batteria dal 100% al 51%"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:115
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:213
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:229
 msgid "Color battery charge medium"
 msgstr "Colore carica batteria media"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:116
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:214
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:215
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:230
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:231
 msgid "The text color for battery charge 50% to 26%"
 msgstr "Il colore del testo per la carica della batteria dal 50% al 26%"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:120
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:220
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:236
 msgid "Color battery charge low"
 msgstr "Colore carica batteria bassa"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:121
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:221
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:222
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:237
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:238
 msgid "The text color for battery charge 25% to 0%"
 msgstr "Il colore del testo per la carica della batteria dal 25% allo 0%"
 
@@ -523,6 +523,18 @@ msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:136
 msgid "Used for inactive time values (-1 disable)"
+msgstr ""
+
+#: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:140
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:190
+msgid "Battery percentage to trigger low battery notification"
+msgstr ""
+
+#: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:141
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:191
+msgid ""
+"When battery percentage falls below this value, a low battery notification "
+"will be triggered"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:9
@@ -595,7 +607,7 @@ msgid "Passed to headsetcontrol to set for voice prompts"
 msgstr "Passato al controllo dell'auricolare per impostare i messaggi vocali"
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:104
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:231
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:247
 msgid "Equalizer"
 msgstr "Equalizzatore"
 
@@ -626,12 +638,12 @@ msgid "Notification on low battery"
 msgstr "Notifica di batteria scarica"
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:144
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:189
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:205
 msgid "Use logging"
 msgstr "Usa log"
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:145
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:201
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:217
 msgid "Use colors"
 msgstr "Usa colori"
 
@@ -647,50 +659,53 @@ msgstr "Intervallo di aggiornamento (minuti)"
 msgid "0 to disable"
 msgstr "0 per disabilitare"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:198
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:189
+msgid "Threshold for low battery notification (%)"
+msgstr ""
+
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:214
 msgid "Colors"
 msgstr "Colori"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:202
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:203
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:218
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:219
 msgid "Enable / disable text colors"
 msgstr "Abilita / disabilita i colori del testo"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:234
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:250
 msgid "Equalizer settings"
 msgstr "Impostazioni dell'equalizzatore"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:265
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:281
 msgid "Equalizer presets"
 msgstr "Preimpostazioni equalizzatore"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:270
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:286
 msgid "Default"
 msgstr "Predefinito"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:284
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:300
 msgid "Values for sidetone"
 msgstr "Valori per il tono laterale"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:285
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:286
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:301
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:302
 msgid "Off Low Medium High Maximum (-1 disable)"
 msgstr "Off Bassa Media Alta Maxssimo (-1 disabilita)"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:290
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:306
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:322
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:338
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:354
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:370
 msgid "Input for headsetcontrol sidetone command"
 msgstr "Input per il comando del tono laterale del controllo dell'auricolare"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:291
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:307
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:323
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:339
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:355
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:384
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:371
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:400
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:416
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:432
@@ -701,23 +716,23 @@ msgstr "Input per il comando del tono laterale del controllo dell'auricolare"
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:512
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:528
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:544
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:560
 msgid "-1 to disable"
 msgstr "-1 per disabilitare"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:374
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:390
 msgid "Inactive Time"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:377
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:393
 msgid "Values for inactive time"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:378
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:379
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:394
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:395
 msgid "Values are used with parameter '-i' (-1 disable)"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:383
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:399
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:415
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:431
@@ -728,5 +743,6 @@ msgstr ""
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:511
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:527
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:543
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:559
 msgid "Input for headsetcontrol inactive time command"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-24 06:08+0200\n"
+"POT-Creation-Date: 2026-04-25 09:05+0200\n"
 "PO-Revision-Date: 2025-11-16 19:27+0100\n"
 "Last-Translator: Christian Lauinger <christian@lauinger-clan.de>\n"
 "Language-Team: \n"
@@ -40,7 +40,7 @@ msgstr "Chatmix"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:136
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:74
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:281
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:297
 msgid "Sidetone"
 msgstr "Zijtoon"
 
@@ -132,22 +132,22 @@ msgid " Minutes"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/extension.js:399
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:239
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:255
 msgid "Setting 1"
 msgstr "Instelling 1"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:400
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:245
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:261
 msgid "Setting 2"
 msgstr "Instelling 2"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:401
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:251
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:267
 msgid "Setting 3"
 msgstr "Instelling 3"
 
 #: HeadsetControl@lauinger-clan.de/extension.js:402
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:257
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:273
 msgid "Setting 4"
 msgstr "Instelling 4"
 
@@ -169,84 +169,84 @@ msgid "Battery low! Please charge your headset."
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/prefs.js:22
-#: HeadsetControl@lauinger-clan.de/prefs.js:104
+#: HeadsetControl@lauinger-clan.de/prefs.js:109
 msgid "Select headsetcontrol executable"
 msgstr "Kies het headsetcontrol-bestand"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:253
-#: HeadsetControl@lauinger-clan.de/prefs.js:268
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:289
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:382
+#: HeadsetControl@lauinger-clan.de/prefs.js:262
+#: HeadsetControl@lauinger-clan.de/prefs.js:277
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:305
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:398
 msgid "Value for Off"
 msgstr "Waarde voor Uit"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:254
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:305
+#: HeadsetControl@lauinger-clan.de/prefs.js:263
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:321
 msgid "Value for Low"
 msgstr "Waarde voor Laag"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:255
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:321
+#: HeadsetControl@lauinger-clan.de/prefs.js:264
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:337
 msgid "Value for Medium"
 msgstr "Waarde voor Gemiddeld"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:256
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:337
+#: HeadsetControl@lauinger-clan.de/prefs.js:265
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:353
 msgid "Value for High"
 msgstr "Waarde voor Hoog"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:257
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:353
+#: HeadsetControl@lauinger-clan.de/prefs.js:266
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:369
 msgid "Value for Maximum"
 msgstr "Waarde voor Maximaal"
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:269
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:398
+#: HeadsetControl@lauinger-clan.de/prefs.js:278
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:414
 msgid "Value 1"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:270
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:414
+#: HeadsetControl@lauinger-clan.de/prefs.js:279
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:430
 msgid "Value 2"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:271
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:430
+#: HeadsetControl@lauinger-clan.de/prefs.js:280
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:446
 msgid "Value 3"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:272
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:446
+#: HeadsetControl@lauinger-clan.de/prefs.js:281
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:462
 msgid "Value 4"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:273
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:462
+#: HeadsetControl@lauinger-clan.de/prefs.js:282
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:478
 msgid "Value 5"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:274
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:478
+#: HeadsetControl@lauinger-clan.de/prefs.js:283
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:494
 msgid "Value 6"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:275
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:494
+#: HeadsetControl@lauinger-clan.de/prefs.js:284
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:510
 msgid "Value 7"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:276
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:510
+#: HeadsetControl@lauinger-clan.de/prefs.js:285
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:526
 msgid "Value 8"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:277
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:526
+#: HeadsetControl@lauinger-clan.de/prefs.js:286
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:542
 msgid "Value 9"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/prefs.js:278
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:542
+#: HeadsetControl@lauinger-clan.de/prefs.js:287
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:558
 msgid "Value 10"
 msgstr ""
 
@@ -357,16 +357,16 @@ msgstr ""
 "Doorgestuurd naar headsetcontrol om de equalizer-instelling in te stellen"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:63
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:235
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:236
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:251
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:252
 msgid "Equalizer options (equalizer might not be supported by your headset)"
 msgstr "Equalizer-opties (mogelijk niet ondersteund door je headset)"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:64
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:240
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:246
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:252
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:258
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:256
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:262
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:268
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:274
 msgid ""
 "Passed to headsetcontrol as parameter to equalizer option (when supported)"
 msgstr ""
@@ -385,8 +385,8 @@ msgstr ""
 "Doorgestuurd naar headsetcontrol om de equalizer-voorinstelling in te stellen"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:73
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:266
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:267
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:282
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:283
 msgid ""
 "Names of the equalizer presets (equalizer preset might not be supported by "
 "your headset)"
@@ -395,8 +395,8 @@ msgstr ""
 "voorkeursinstellingen worden mogelijk niet ondersteund door uw headset)"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:75
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:271
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:272
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:287
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:288
 msgid "Shown in equalizer preset menu (when supported)"
 msgstr "Weergegeven in het equalizer-voorkeuzemenu (indien ondersteund)"
 
@@ -415,8 +415,8 @@ msgid "Parameter to enable log outputs"
 msgstr "Optie om een logboek bij te houden"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:85
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:190
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:191
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:206
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:207
 msgid "Enable / disable log outputs"
 msgstr "Schakel logboek bijhouden in/uit"
 
@@ -459,35 +459,35 @@ msgid "Makes battery percentage text colored/non-colored"
 msgstr "Voorzie het accupercentage van een kleur"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:110
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:206
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:222
 msgid "Color battery charge high"
 msgstr "Kleur van hoog accuniveau"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:111
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:207
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:208
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:223
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:224
 msgid "The text color for battery charge 100% to 51%"
 msgstr "De tekstkleur van een oplaadniveau tussen 100% en 51%"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:115
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:213
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:229
 msgid "Color battery charge medium"
 msgstr "Kleur van gemiddeld accuniveau"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:116
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:214
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:215
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:230
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:231
 msgid "The text color for battery charge 50% to 26%"
 msgstr "De tekstkleur van een oplaadniveau tussen 50% en 26%"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:120
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:220
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:236
 msgid "Color battery charge low"
 msgstr "Kleur van laag accuniveau"
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:121
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:221
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:222
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:237
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:238
 msgid "The text color for battery charge 25% to 0%"
 msgstr "De tekstkleur van een oplaadniveau tussen 25% en 0%"
 
@@ -515,6 +515,18 @@ msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:136
 msgid "Used for inactive time values (-1 disable)"
+msgstr ""
+
+#: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:140
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:190
+msgid "Battery percentage to trigger low battery notification"
+msgstr ""
+
+#: HeadsetControl@lauinger-clan.de/schemas/org.gnome.shell.extensions.HeadsetControl.gschema.xml:141
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:191
+msgid ""
+"When battery percentage falls below this value, a low battery notification "
+"will be triggered"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:9
@@ -587,7 +599,7 @@ msgstr ""
 "Wordt doorgestuurd naar headsetcontrol om gesproken teksten in te stellen"
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:104
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:231
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:247
 msgid "Equalizer"
 msgstr "Equalizer"
 
@@ -618,12 +630,12 @@ msgid "Notification on low battery"
 msgstr ""
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:144
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:189
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:205
 msgid "Use logging"
 msgstr "Logboek bijhouden"
 
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:145
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:201
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:217
 msgid "Use colors"
 msgstr "Kleuren gebruiken"
 
@@ -639,50 +651,53 @@ msgstr ""
 msgid "0 to disable"
 msgstr "0 om uit te schakelen"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:198
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:189
+msgid "Threshold for low battery notification (%)"
+msgstr ""
+
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:214
 msgid "Colors"
 msgstr "Kleuren"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:202
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:203
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:218
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:219
 msgid "Enable / disable text colors"
 msgstr "Schakel tekstkleuren in/uit"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:234
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:250
 msgid "Equalizer settings"
 msgstr "Equalizer-instellingen"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:265
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:281
 msgid "Equalizer presets"
 msgstr "Equalizer-voorinstellingen"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:270
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:286
 msgid "Default"
 msgstr "Standaard"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:284
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:300
 msgid "Values for sidetone"
 msgstr "Waardes voor zijtoon"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:285
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:286
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:301
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:302
 msgid "Off Low Medium High Maximum (-1 disable)"
 msgstr "Uit Laag Gemiddeld Hoog Maximaal (-1 uitschakelen)"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:290
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:306
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:322
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:338
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:354
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:370
 msgid "Input for headsetcontrol sidetone command"
 msgstr "Invoer voor headsetcontrol zijtoon commando"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:291
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:307
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:323
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:339
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:355
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:384
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:371
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:400
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:416
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:432
@@ -693,23 +708,23 @@ msgstr "Invoer voor headsetcontrol zijtoon commando"
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:512
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:528
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:544
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:560
 msgid "-1 to disable"
 msgstr "-1 om uit te schakelen"
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:374
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:390
 msgid "Inactive Time"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:377
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:393
 msgid "Values for inactive time"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:378
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:379
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:394
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:395
 msgid "Values are used with parameter '-i' (-1 disable)"
 msgstr ""
 
-#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:383
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:399
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:415
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:431
@@ -720,5 +735,6 @@ msgstr ""
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:511
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:527
 #: HeadsetControl@lauinger-clan.de/ui/prefs.ui:543
+#: HeadsetControl@lauinger-clan.de/ui/prefs.ui:559
 msgid "Input for headsetcontrol inactive time command"
 msgstr ""


### PR DESCRIPTION
Introduce a new preference allowing users to set the battery percentage at which low battery notifications are triggered. This replaces the previously hardcoded 25% threshold, providing more flexibility for users to customize alerts.
