### PR TITLE
Updates extension for GNOME Shell 51 compatibility

### DIFF
--- a/HeadsetControl@lauinger-clan.de/extension.js
+++ b/HeadsetControl@lauinger-clan.de/extension.js
@@ -65,7 +65,9 @@ async function invokeCmd(cmd, logger, testMode = 0, cancellable = null, subproce
                     const [, stdoutFinish] = subprocess.communicate_utf8_finish(res);
                     resolve(stdoutFinish);
                 } catch (err) {
-                    logger.error(`Error executing command: ${err.message}`);
+                    if (!cancellable?.is_cancelled()) {
+                        logger.error(`Error executing command: ${err.message}`);
+                    }
                     reject(err);
                 }
             });

--- a/HeadsetControl@lauinger-clan.de/extension.js
+++ b/HeadsetControl@lauinger-clan.de/extension.js
@@ -11,7 +11,6 @@ import * as PopupMenu from "resource:///org/gnome/shell/ui/popupMenu.js";
 import * as QuickSettings from "resource:///org/gnome/shell/ui/quickSettings.js";
 import * as MessageTray from "resource:///org/gnome/shell/ui/messageTray.js";
 import { Extension, gettext as _ } from "resource:///org/gnome/shell/extensions/extension.js";
-import { PopupAnimation } from "resource:///org/gnome/shell/ui/boxpointer.js";
 
 const QuickSettingsMenu = Main.panel.statusArea.quickSettings;
 const capabilities = {
@@ -213,7 +212,7 @@ const HeadsetControlMenuToggle = GObject.registerClass(
             this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
             const settingsItem = this.menu.addAction(_("Settings"), () => {
                 extension.openPreferences();
-                QuickSettingsMenu.menu.close(PopupAnimation.FADE);
+                QuickSettingsMenu.menu.close({ fadeOnly: true });
             });
             settingsItem.visible = Main.sessionMode.allowSettings;
             this.menu._settingsActions[extension.uuid] = settingsItem;

--- a/HeadsetControl@lauinger-clan.de/extension.js
+++ b/HeadsetControl@lauinger-clan.de/extension.js
@@ -39,17 +39,28 @@ const headsetcontrolCommands = {
     cmdEqualizerPreset: "",
 };
 
-async function invokeCmd(cmd, logger, testMode = 0) {
-    const flags = Gio.SubprocessFlags.STDOUT_PIPE;
-    const [, argv] = GLib.shell_parse_argv(cmd);
-    if (testMode > 0) {
-        argv.push("--test-device", testMode.toString());
+function resetRuntimeState() {
+    for (const capability in capabilities) {
+        capabilities[capability] = false;
     }
-    const proc = new Gio.Subprocess({ argv, flags });
-    proc.init(null);
+    for (const command in headsetcontrolCommands) {
+        headsetcontrolCommands[command] = "";
+    }
+}
+
+async function invokeCmd(cmd, logger, testMode = 0, cancellable = null, subprocesses = null) {
+    let proc = null;
     try {
+        const flags = Gio.SubprocessFlags.STDOUT_PIPE;
+        const [, argv] = GLib.shell_parse_argv(cmd);
+        if (testMode > 0) {
+            argv.push("--test-device", testMode.toString());
+        }
+        proc = new Gio.Subprocess({ argv, flags });
+        proc.init(null);
+        subprocesses?.add(proc);
         const stdout = await new Promise((resolve, reject) => {
-            proc.communicate_utf8_async(null, null, (subprocess, res) => {
+            proc.communicate_utf8_async(null, cancellable, (subprocess, res) => {
                 try {
                     const [, stdoutFinish] = subprocess.communicate_utf8_finish(res);
                     resolve(stdoutFinish);
@@ -66,9 +77,14 @@ async function invokeCmd(cmd, logger, testMode = 0) {
             return strOutput.split("###")[1];
         }
     } catch (err) {
-        // could not execute the command
-        logger.error(err);
-        return "N/A";
+        if (!cancellable?.is_cancelled()) {
+            logger.error(err);
+        }
+        return null;
+    } finally {
+        if (proc !== null) {
+            subprocesses?.delete(proc);
+        }
     }
 }
 
@@ -92,6 +108,8 @@ const HeadsetControlMenuToggle = GObject.registerClass(
             this._valueChatMix = "";
             this._valueHeadsetname = _("HeadsetControl");
             this._testMode = extension._testMode;
+            this._cancellable = extension._cancellable;
+            this._subprocesses = extension._subprocesses;
             //remember style
             this._originalStyle = this.get_style();
             this.menu.setHeader("audio-headset-symbolic", _("HeadsetControl"), "");
@@ -308,7 +326,13 @@ const HeadsetControlMenuToggle = GObject.registerClass(
 
         async _invokeCmd(cmd) {
             this._logOutput("_invokeCmd: " + cmd);
-            const retval = await invokeCmd(cmd, this._logger, this._testMode);
+            const retval = await invokeCmd(
+                cmd,
+                this._logger,
+                this._testMode,
+                this._cancellable,
+                this._subprocesses
+            );
             this._logOutput("_invokeCmd retval: " + retval);
             return retval;
         }
@@ -561,9 +585,19 @@ export default class HeadsetControl extends Extension {
 
     async _invokeCmd(cmd) {
         this._logOutput("_invokeCmd: " + cmd);
-        const retval = await invokeCmd(cmd, this.getLogger(), this._testMode);
+        const retval = await invokeCmd(
+            cmd,
+            this.getLogger(),
+            this._testMode,
+            this._cancellable,
+            this._subprocesses
+        );
         this._logOutput("_invokeCmd retval: " + retval);
         return retval;
+    }
+
+    _isCancelled(cancellable) {
+        return cancellable !== this._cancellable || cancellable.is_cancelled();
     }
 
     _initCmd() {
@@ -738,8 +772,12 @@ export default class HeadsetControl extends Extension {
     }
 
     async _refreshJSON() {
+        const cancellable = this._cancellable;
         try {
             const stdout = await this._invokeCmd(headsetcontrolCommands.cmdOutputFormat);
+            if (this._isCancelled(cancellable)) {
+                return;
+            }
             if (!stdout || stdout === "N/A") {
                 throw new Error("No output received from command");
             }
@@ -755,30 +793,46 @@ export default class HeadsetControl extends Extension {
             this._JSONoutputSupported = false;
             // Fallback to non-JSON method
             await this._refreshCapabilities();
+            if (this._isCancelled(cancellable)) {
+                return;
+            }
             if (capabilities.battery) {
                 await this._refreshBatteryStatus();
+                if (this._isCancelled(cancellable)) {
+                    return;
+                }
             }
             if (capabilities.chatmix) {
                 await this._refreshChatMixStatus();
             }
         } finally {
-            this._headsetControlIndicator.updateUIElements();
-            this._changeIndicatorVisibility();
-            this._notifyLowBattery(
-                this._headsetControlIndicator.headsetControlMenuToggle.valueBatteryStatus,
-                this._headsetControlIndicator.valueBatteryNum
-            );
+            if (!this._isCancelled(cancellable)) {
+                this._headsetControlIndicator.updateUIElements();
+                this._changeIndicatorVisibility();
+                this._notifyLowBattery(
+                    this._headsetControlIndicator.headsetControlMenuToggle.valueBatteryStatus,
+                    this._headsetControlIndicator.valueBatteryNum
+                );
+            }
         }
     }
 
     async _refreshJSONupdate(updateIndicator) {
+        const cancellable = this._cancellable;
         this._JSONoutputSupported = false;
         const strOutput = await this._readJSONOutputFormat("");
+        if (this._isCancelled(cancellable)) {
+            return false;
+        }
         return this._processOutput(strOutput, updateIndicator);
     }
 
     async _refreshCapabilities() {
+        const cancellable = this._cancellable;
         const strOutput = await this._invokeCmd(headsetcontrolCommands.cmdCapabilities);
+        if (this._isCancelled(cancellable)) {
+            return;
+        }
 
         // if we cannot get the capabilities, set all to true
         if (!strOutput || strOutput.includes("No supported headset found")) {
@@ -828,7 +882,11 @@ export default class HeadsetControl extends Extension {
     }
 
     async _refreshBatteryStatus() {
+        const cancellable = this._cancellable;
         const strOutput = await this._invokeCmd(headsetcontrolCommands.cmdBattery);
+        if (this._isCancelled(cancellable)) {
+            return false;
+        }
 
         if (!strOutput) {
             return false;
@@ -844,7 +902,11 @@ export default class HeadsetControl extends Extension {
     }
 
     async _refreshChatMixStatus() {
+        const cancellable = this._cancellable;
         const strOutput = await this._invokeCmd(headsetcontrolCommands.cmdChatMix);
+        if (this._isCancelled(cancellable)) {
+            return false;
+        }
 
         if (!strOutput) {
             return false;
@@ -876,6 +938,7 @@ export default class HeadsetControl extends Extension {
     }
 
     async _refreshIndicator() {
+        const cancellable = this._cancellable;
         this._logOutput("_refreshIndicator - " + _("Refreshing..."));
         if (this._JSONoutputSupported) {
             await this._refreshJSON();
@@ -883,6 +946,9 @@ export default class HeadsetControl extends Extension {
         }
         if (capabilities.battery) {
             await this._refreshBatteryStatus();
+            if (this._isCancelled(cancellable)) {
+                return;
+            }
             this._headsetControlIndicator.updateUIElements();
             this._changeIndicatorVisibility();
             this._notifyLowBattery(
@@ -893,6 +959,7 @@ export default class HeadsetControl extends Extension {
     }
 
     async _refresh() {
+        const cancellable = this._cancellable;
         if (this._refreshIndicatorRunning) {
             this._logOutput(_("Quicksettings open - refresh indicator running..."));
             return;
@@ -910,12 +977,21 @@ export default class HeadsetControl extends Extension {
         }
         if (this._needCapabilitiesRefresh) {
             await this._refreshCapabilities();
+            if (this._isCancelled(cancellable)) {
+                return;
+            }
         }
         if (capabilities.battery) {
             await this._refreshBatteryStatus();
+            if (this._isCancelled(cancellable)) {
+                return;
+            }
         }
         if (capabilities.chatmix) {
             await this._refreshChatMixStatus();
+            if (this._isCancelled(cancellable)) {
+                return;
+            }
         }
         this._headsetControlIndicator.updateUIElements();
         this._changeIndicatorVisibility();
@@ -1000,10 +1076,17 @@ export default class HeadsetControl extends Extension {
     }
 
     async _updateBinaryCapabilities() {
+        const cancellable = this._cancellable;
         this._logOutput("_updateBinaryCapabilities - calling _refreshJSONupdate");
         const ret = await this._refreshJSONupdate(this._showIndicator);
+        if (this._isCancelled(cancellable)) {
+            return;
+        }
         if (!ret) {
             await this._refreshCapabilities();
+            if (this._isCancelled(cancellable)) {
+                return;
+            }
         }
         await this._refreshIndicator();
     }
@@ -1050,17 +1133,19 @@ export default class HeadsetControl extends Extension {
     }
 
     enable() {
+        resetRuntimeState();
         this._devicecount = 0;
         this._visible = false;
         this._refreshIndicatorRunning = false;
         this._batteryLowNotified = false;
+        this._needCapabilitiesRefresh = true;
+        this._JSONoutputSupported = true;
         this._settings = this.getSettings();
+        this._cancellable = new Gio.Cancellable();
+        this._subprocesses = new Set();
 
         this._testMode = 0;
         this._settings.set_int("test-mode", 0); // make sure test mode is off when extension is enabled
-
-        this._headsetControlIndicator = new HeadsetControlIndicator(this);
-        this._initCmd();
         this._notificationLowBattery = this._settings.get_boolean("notification-low-battery");
         this._lowBatteryThreshold = this._settings.get_int("low-battery-threshold");
         this._useLogging = this._settings.get_boolean("use-logging");
@@ -1069,6 +1154,8 @@ export default class HeadsetControl extends Extension {
         this._hideWhenDisconnectedSystemindicator = this._settings.get_boolean("hidewhendisconnected-systemindicator");
         this._refreshIntervalSystemindicator = this._settings.get_int("refreshinterval-systemindicator");
 
+        this._headsetControlIndicator = new HeadsetControlIndicator(this);
+        this._initCmd();
         this._updateBinaryCapabilities();
         this._refreshIntervalSignal = null;
         this._refreshIntervalHandler(false);
@@ -1106,7 +1193,7 @@ export default class HeadsetControl extends Extension {
                 callback: this._initCmd.bind(this),
             },
             {
-                key: "option-rotatemute",
+                key: "option-rotate-mute",
                 callback: this._initCmd.bind(this),
             },
             {
@@ -1118,7 +1205,7 @@ export default class HeadsetControl extends Extension {
                 callback: this._initCmd.bind(this),
             },
             {
-                key: "option-equalizerpreset",
+                key: "option-equalizer-preset",
                 callback: this._initCmd.bind(this),
             },
             { key: "notification-low-battery", callback: this._onParamChangedLogNot.bind(this) },
@@ -1168,6 +1255,11 @@ export default class HeadsetControl extends Extension {
     }
 
     disable() {
+        this._cancellable.cancel();
+        for (const subprocess of this._subprocesses) {
+            subprocess.force_exit();
+        }
+        this._subprocesses.clear();
         if (this._refreshIntervalSignal !== null) {
             GLib.Source.remove(this._refreshIntervalSignal);
         }
@@ -1196,5 +1288,8 @@ export default class HeadsetControl extends Extension {
         this._lowBatteryThreshold = null;
         this._useLogging = null;
         this._useColors = null;
+        this._cancellable = null;
+        this._subprocesses = null;
+        resetRuntimeState();
     }
 }

--- a/HeadsetControl@lauinger-clan.de/metadata.json
+++ b/HeadsetControl@lauinger-clan.de/metadata.json
@@ -3,7 +3,7 @@
     "gettext-domain": "HeadsetControl",
     "description": "Gnome Shell Extension to visualize headset status from HeadsetControl (https://github.com/Sapd/HeadsetControl) command line tool.\nSupported capabilities can also be controlled like ChatMix, Sidetone, Equalizer etc.",
     "uuid": "HeadsetControl@lauinger-clan.de",
-    "shell-version": ["48", "49", "50"],
+    "shell-version": ["48", "49", "50", "51"],
     "url": "https://github.com/ChrisLauinger77/gnome-shell-extension-HeadsetControl",
     "settings-schema": "org.gnome.shell.extensions.HeadsetControl",
     "donations": {
@@ -12,5 +12,5 @@
         "paypal": "ChrisLauinger"
     },
     "version": 999,
-    "version-name": "50.6"
+    "version-name": "51.0"
 }

--- a/HeadsetControl@lauinger-clan.de/metadata.json
+++ b/HeadsetControl@lauinger-clan.de/metadata.json
@@ -3,7 +3,7 @@
     "gettext-domain": "HeadsetControl",
     "description": "Gnome Shell Extension to visualize headset status from HeadsetControl (https://github.com/Sapd/HeadsetControl) command line tool.\nSupported capabilities can also be controlled like ChatMix, Sidetone, Equalizer etc.",
     "uuid": "HeadsetControl@lauinger-clan.de",
-    "shell-version": ["48", "49", "50", "51"],
+    "shell-version": ["51"],
     "url": "https://github.com/ChrisLauinger77/gnome-shell-extension-HeadsetControl",
     "settings-schema": "org.gnome.shell.extensions.HeadsetControl",
     "donations": {

--- a/HeadsetControl@lauinger-clan.de/prefs.js
+++ b/HeadsetControl@lauinger-clan.de/prefs.js
@@ -7,8 +7,8 @@ import GObject from "gi://GObject";
 import { ExtensionPreferences, gettext as _ } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
 
 export default class AdwPrefs extends ExtensionPreferences {
-    changeOption(option, text) {
-        this.getSettings().set_string(option, text);
+    changeOption(settings, option, text) {
+        settings.set_string(option, text);
     }
 
     _onBtnClicked(btn, filechooser) {
@@ -24,64 +24,64 @@ export default class AdwPrefs extends ExtensionPreferences {
         filechooser.show();
     }
 
-    _updateExecutable(valueExecutable) {
-        valueExecutable.set_text(this.getSettings().get_string("headsetcontrol-executable"));
+    _updateExecutable(settings, valueExecutable) {
+        valueExecutable.set_text(settings.get_string("headsetcontrol-executable"));
     }
 
-    _onFileChooserResponse(native, response) {
+    _onFileChooserResponse(window, native, response) {
         if (response !== Gtk.ResponseType.ACCEPT) {
             return;
         }
         const fileURI = native.get_file().get_uri().replace("file://", "");
 
-        this.changeOption("headsetcontrol-executable", fileURI);
+        window._settings.set_string("headsetcontrol-executable", fileURI);
     }
 
-    _applyChanges(valueExecutable, options) {
-        this.changeOption("headsetcontrol-executable", valueExecutable.get_text());
-        this.changeOption("option-output-format", options.opt_oformat.get_text());
-        this.changeOption("option-capabilities", options.opt_capa.get_text());
-        this.changeOption("option-battery", options.opt_bat.get_text());
-        this.changeOption("option-chatmix", options.opt_chm.get_text());
-        this.changeOption("option-sidetone", options.opt_sto.get_text());
-        this.changeOption("option-led", options.opt_led.get_text());
-        this.changeOption("option-inactive-time", options.opt_iat.get_text());
-        this.changeOption("option-voice", options.opt_voice.get_text());
-        this.changeOption("option-rotate-mute", options.opt_rot.get_text());
-        this.changeOption("option-equalizer", options.opt_equalizer.get_text());
-        this.changeOption("option-equalizer-preset", options.opt_equalizer_preset.get_text());
+    _applyChanges(settings, valueExecutable, options) {
+        this.changeOption(settings, "headsetcontrol-executable", valueExecutable.get_text());
+        this.changeOption(settings, "option-output-format", options.opt_oformat.get_text());
+        this.changeOption(settings, "option-capabilities", options.opt_capa.get_text());
+        this.changeOption(settings, "option-battery", options.opt_bat.get_text());
+        this.changeOption(settings, "option-chatmix", options.opt_chm.get_text());
+        this.changeOption(settings, "option-sidetone", options.opt_sto.get_text());
+        this.changeOption(settings, "option-led", options.opt_led.get_text());
+        this.changeOption(settings, "option-inactive-time", options.opt_iat.get_text());
+        this.changeOption(settings, "option-voice", options.opt_voice.get_text());
+        this.changeOption(settings, "option-rotate-mute", options.opt_rot.get_text());
+        this.changeOption(settings, "option-equalizer", options.opt_equalizer.get_text());
+        this.changeOption(settings, "option-equalizer-preset", options.opt_equalizer_preset.get_text());
     }
 
-    _onColorChanged(color_setting_button, strSetting) {
-        this.getSettings().set_string(strSetting, color_setting_button.get_rgba().to_string());
+    _onColorChanged(settings, color_setting_button, strSetting) {
+        settings.set_string(strSetting, color_setting_button.get_rgba().to_string());
     }
 
-    _onEQvaluechanged(adwrow, index, option) {
-        const arrayEQsettings = this.getSettings().get_strv(option);
+    _onEQvaluechanged(settings, adwrow, index, option) {
+        const arrayEQsettings = settings.get_strv(option);
         arrayEQsettings[index] = adwrow.get_text();
-        this.getSettings().set_strv(option, arrayEQsettings);
+        settings.set_strv(option, arrayEQsettings);
     }
 
-    _onSTvaluechanged(adwrow, index) {
-        const arraySidetone = this.getSettings().get_strv("sidetone-values");
+    _onSTvaluechanged(settings, adwrow, index) {
+        const arraySidetone = settings.get_strv("sidetone-values");
         arraySidetone[index] = adwrow.get_value().toString();
-        this.getSettings().set_strv("sidetone-values", arraySidetone);
+        settings.set_strv("sidetone-values", arraySidetone);
     }
 
-    _onITvaluechanged(adwrow, index) {
-        const arrayInactiveTime = this.getSettings().get_strv("inactivetime-values");
+    _onITvaluechanged(settings, adwrow, index) {
+        const arrayInactiveTime = settings.get_strv("inactivetime-values");
         arrayInactiveTime[index] = adwrow.get_value().toString();
-        this.getSettings().set_strv("inactivetime-values", arrayInactiveTime);
+        settings.set_strv("inactivetime-values", arrayInactiveTime);
     }
 
-    _onRIvaluechanged(adwrow) {
+    _onRIvaluechanged(settings, adwrow) {
         const value = adwrow.get_value();
-        this.getSettings().set_int("refreshinterval-systemindicator", value);
+        settings.set_int("refreshinterval-systemindicator", value);
     }
 
-    _onBTvaluechanged(adwrow) {
+    _onBTvaluechanged(settings, adwrow) {
         const value = adwrow.get_value();
-        this.getSettings().set_int("low-battery-threshold", value);
+        settings.set_int("low-battery-threshold", value);
     }
 
     _onQSToggleValuechanged(_settings, cmb) {
@@ -105,7 +105,7 @@ export default class AdwPrefs extends ExtensionPreferences {
         valueExecutable.set_text(window._settings.get_string("headsetcontrol-executable"));
         window._settings.connect(
             "changed::headsetcontrol-executable",
-            this._updateExecutable.bind(this, valueExecutable)
+            this._updateExecutable.bind(this, window._settings, valueExecutable)
         );
         const buttonExecutable = builder.get_object("HeadsetControl_row_commandselect");
 
@@ -115,7 +115,7 @@ export default class AdwPrefs extends ExtensionPreferences {
             action: Gtk.FileChooserAction.OPEN,
         });
         buttonExecutable.connect("activated", this._onBtnClicked.bind(this, buttonExecutable, _filechooser));
-        _filechooser.connect("response", this._onFileChooserResponse.bind(this));
+        _filechooser.connect("response", this._onFileChooserResponse.bind(this, window));
 
         // test mode
         adwrow = builder.get_object("HeadsetControl_row_testmodeselect");
@@ -123,31 +123,31 @@ export default class AdwPrefs extends ExtensionPreferences {
         adwrow.connect("notify", this._onTestModeValuechanged.bind(this, window._settings, adwrow));
 
         const opt_oformat = builder.get_object("HeadsetControl_row_outputformat_new2");
-        opt_oformat.set_text(_(this.getSettings().get_string("option-output-format")));
+        opt_oformat.set_text(_(window._settings.get_string("option-output-format")));
         const opt_capa = builder.get_object("HeadsetControl_row_outputformat_old2");
-        opt_capa.set_text(_(this.getSettings().get_string("option-capabilities")));
+        opt_capa.set_text(_(window._settings.get_string("option-capabilities")));
         const opt_bat = builder.get_object("HeadsetControl_row_outputformat_old3");
-        opt_bat.set_text(_(this.getSettings().get_string("option-battery")));
+        opt_bat.set_text(_(window._settings.get_string("option-battery")));
         const opt_chm = builder.get_object("HeadsetControl_row_outputformat_old4");
-        opt_chm.set_text(_(this.getSettings().get_string("option-chatmix")));
+        opt_chm.set_text(_(window._settings.get_string("option-chatmix")));
         const opt_sto = builder.get_object("HeadsetControl_row_common2");
-        opt_sto.set_text(_(this.getSettings().get_string("option-sidetone")));
+        opt_sto.set_text(_(window._settings.get_string("option-sidetone")));
         const opt_led = builder.get_object("HeadsetControl_row_common3");
-        opt_led.set_text(_(this.getSettings().get_string("option-led")));
+        opt_led.set_text(_(window._settings.get_string("option-led")));
         const opt_iat = builder.get_object("HeadsetControl_row_common4");
-        opt_iat.set_text(_(this.getSettings().get_string("option-inactive-time")));
+        opt_iat.set_text(_(window._settings.get_string("option-inactive-time")));
         const opt_voice = builder.get_object("HeadsetControl_row_common5");
-        opt_voice.set_text(_(this.getSettings().get_string("option-voice")));
+        opt_voice.set_text(_(window._settings.get_string("option-voice")));
         const opt_rot = builder.get_object("HeadsetControl_row_common6");
-        opt_rot.set_text(_(this.getSettings().get_string("option-rotate-mute")));
+        opt_rot.set_text(_(window._settings.get_string("option-rotate-mute")));
         const opt_equalizer = builder.get_object("HeadsetControl_row_common7");
-        opt_equalizer.set_text(_(this.getSettings().get_string("option-equalizer")));
+        opt_equalizer.set_text(_(window._settings.get_string("option-equalizer")));
         const opt_equalizer_preset = builder.get_object("HeadsetControl_row_common8");
-        opt_equalizer_preset.set_text(_(this.getSettings().get_string("option-equalizer-preset")));
+        opt_equalizer_preset.set_text(_(window._settings.get_string("option-equalizer-preset")));
         const buttonApply = builder.get_object("HeadsetControl_row_apply");
         buttonApply.connect(
             "activated",
-            this._applyChanges.bind(this, valueExecutable, {
+            this._applyChanges.bind(this, window._settings, valueExecutable, {
                 opt_oformat,
                 opt_capa,
                 opt_bat,
@@ -190,15 +190,15 @@ export default class AdwPrefs extends ExtensionPreferences {
         window._settings.bind("hidewhendisconnected-systemindicator", adwrow, "active", Gio.SettingsBindFlags.DEFAULT);
         // refresh interval
         adwrow = builder.get_object("HeadsetControl_row_showindicator3");
-        adwrow.set_value(this.getSettings().get_int("refreshinterval-systemindicator"));
-        adwrow.connect("changed", this._onRIvaluechanged.bind(this, adwrow));
+        adwrow.set_value(window._settings.get_int("refreshinterval-systemindicator"));
+        adwrow.connect("changed", this._onRIvaluechanged.bind(this, window._settings, adwrow));
         // notification for low battery
         adwrow = builder.get_object("HeadsetControl_row_notifications");
         window._settings.bind("notification-low-battery", adwrow, "active", Gio.SettingsBindFlags.DEFAULT);
         // low battery threshold
         adwrow = builder.get_object("HeadsetControl_row_lowbatterythreshold");
-        adwrow.set_value(this.getSettings().get_int("low-battery-threshold"));
-        adwrow.connect("changed", this._onBTvaluechanged.bind(this, adwrow));
+        adwrow.set_value(window._settings.get_int("low-battery-threshold"));
+        adwrow.connect("changed", this._onBTvaluechanged.bind(this, window._settings, adwrow));
         //use logging
         adwrow = builder.get_object("HeadsetControl_row_logging");
         window._settings.bind("use-logging", adwrow, "active", Gio.SettingsBindFlags.DEFAULT);
@@ -222,7 +222,10 @@ export default class AdwPrefs extends ExtensionPreferences {
 
         mycolor.parse(window._settings.get_string("color-batteryhigh"));
         colorbatteryhigh.set_rgba(mycolor);
-        colorbatteryhigh.connect("color-set", this._onColorChanged.bind(this, colorbatteryhigh, "color-batteryhigh"));
+        colorbatteryhigh.connect(
+            "color-set",
+            this._onColorChanged.bind(this, window._settings, colorbatteryhigh, "color-batteryhigh")
+        );
         adwrow.add_suffix(colorbatteryhigh);
         adwrow.activatable_widget = colorbatteryhigh;
         // color medium charge
@@ -235,7 +238,7 @@ export default class AdwPrefs extends ExtensionPreferences {
         colorbatterymedium.set_rgba(mycolor);
         colorbatterymedium.connect(
             "color-set",
-            this._onColorChanged.bind(this, colorbatterymedium, "color-batterymedium")
+            this._onColorChanged.bind(this, window._settings, colorbatterymedium, "color-batterymedium")
         );
         adwrow.add_suffix(colorbatterymedium);
         adwrow.activatable_widget = colorbatterymedium;
@@ -247,7 +250,10 @@ export default class AdwPrefs extends ExtensionPreferences {
         });
         mycolor.parse(window._settings.get_string("color-batterylow"));
         colorbatterylow.set_rgba(mycolor);
-        colorbatterylow.connect("color-set", this._onColorChanged.bind(this, colorbatterylow, "color-batterylow"));
+        colorbatterylow.connect(
+            "color-set",
+            this._onColorChanged.bind(this, window._settings, colorbatterylow, "color-batterylow")
+        );
         adwrow.add_suffix(colorbatterylow);
         adwrow.activatable_widget = colorbatterylow;
         //equalizer
@@ -259,7 +265,7 @@ export default class AdwPrefs extends ExtensionPreferences {
             adwrowEQ.set_text(_(value));
             adwrowEQ.connect(
                 "changed",
-                this._onEQvaluechanged.bind(this, adwrowEQ, index, "option-equalizer-settings")
+                this._onEQvaluechanged.bind(this, window._settings, adwrowEQ, index, "option-equalizer-settings")
             );
         }
         //equalizer preset
@@ -274,12 +280,12 @@ export default class AdwPrefs extends ExtensionPreferences {
             _("Value for High"),
             _("Value for Maximum"),
         ];
-        const arraySidetone = this.getSettings().get_strv("sidetone-values");
+        const arraySidetone = window._settings.get_strv("sidetone-values");
         for (const [index] of sidetoneLabels.entries()) {
             adwrow = builder.get_object("HeadsetControl_row_sidetone" + (index + 1));
             if (!adwrow) continue; // Prevent TypeError
             adwrow.set_value(Number.parseInt(arraySidetone[index]) || 0);
-            adwrow.connect("changed", this._onSTvaluechanged.bind(this, adwrow, index));
+            adwrow.connect("changed", this._onSTvaluechanged.bind(this, window._settings, adwrow, index));
         }
         //inactive time
         const inactiveTimeLabels = [
@@ -295,12 +301,12 @@ export default class AdwPrefs extends ExtensionPreferences {
             _("Value 9"),
             _("Value 10"),
         ];
-        const arrayInactiveTime = this.getSettings().get_strv("inactivetime-values");
+        const arrayInactiveTime = window._settings.get_strv("inactivetime-values");
         for (const [index] of inactiveTimeLabels.entries()) {
             adwrow = builder.get_object("HeadsetControl_row_inactivetime" + (index + 1));
             if (!adwrow) continue; // Prevent TypeError
             adwrow.set_value(Number.parseInt(arrayInactiveTime[index]) || 0);
-            adwrow.connect("changed", this._onITvaluechanged.bind(this, adwrow, index));
+            adwrow.connect("changed", this._onITvaluechanged.bind(this, window._settings, adwrow, index));
         }
         window.add(page2);
     }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-![Gnome Extensions Downloads](https://img.shields.io/gnome-extensions/dt/HeadsetControl@lauinger-clan.de) ![GNOME Shell](https://img.shields.io/badge/GNOME-42%20--%2050-blue?logo=gnome&logoColor=white) ![GitHub License](https://img.shields.io/github/license/ChrisLauinger77/gnome-shell-extension-HeadsetControl)
+![Gnome Extensions Downloads](https://img.shields.io/gnome-extensions/dt/HeadsetControl@lauinger-clan.de) ![GNOME Shell](https://img.shields.io/badge/GNOME-42%20--%2051-blue?logo=gnome&logoColor=white) ![GitHub License](https://img.shields.io/github/license/ChrisLauinger77/gnome-shell-extension-HeadsetControl)
 
 </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gnome-shell-extension-headsetcontrol",
-  "version": "1.0.0",
+  "version": "51.0.0",
   "description": "Gnome Shell Extension to visualize headset status from HeadsetControl",
   "main": "HeadsetControl@lauinger-clan.de/extension.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- declare GNOME Shell 51 compatibility and update the extension version name
- make `headsetcontrol` command parsing and startup failures recoverable
- track and cancel asynchronous subprocess work during extension teardown
- prevent stale refresh callbacks from updating destroyed or re-enabled UI
- reset cached capability and command state across disable/re-enable cycles
- correct the rotate-mute and equalizer-preset GSettings change handlers

## Review focus

- GNOME Shell 51 metadata compatibility
- `enable()` / `disable()` lifecycle symmetry
- subprocess cancellation and cleanup
- GSettings key consistency

## Validation

- ESLint
- Shexli static analysis
- strict GSettings schema validation
- extension packaging and ZIP integrity inspection

## Breaking changes

None. Existing settings require no migration.
