### PR TITLE
Add install-dependencies helper command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,17 +29,20 @@ lives in `HeadsetControl@lauinger-clan.de/metadata.json`.
 - `.github/workflows/eslint.yml`: CI lint scan.
 - `.github/workflows/release.yml`: release packaging and EGO upload workflow.
 
-## Development Commands
+## Useful Commands
 
 Run from the repository root unless noted otherwise.
 
 ```bash
-npm install
+./headsetcontrol.sh install-dependencies
 npm run lint
 ./headsetcontrol.sh zip
 ./headsetcontrol.sh install
 ./headsetcontrol.sh translate
 ```
+
+Run `./headsetcontrol.sh install-dependencies` after pulling or rebasing remote
+changes that modify `package-lock.json`, particularly Renovate updates.
 
 Notes:
 

--- a/headsetcontrol.sh
+++ b/headsetcontrol.sh
@@ -80,6 +80,9 @@ update_version() {
 }
 
 case "${1:-}" in
+  install-dependencies)
+    npm ci
+    ;;
   cleanup)
     if [[ -f "$extensionfile" ]]; then
       rm -- "$extensionfile"
@@ -135,7 +138,7 @@ case "${1:-}" in
     echo "Done."
     ;;
   *)
-    echo "Usage: $0 {zip|pack|install|translate|upload|cleanup|check-version|update-version|setup-hooks}"
+    echo "Usage: $0 {install-dependencies|zip|pack|install|translate|upload|cleanup|check-version|update-version|setup-hooks}"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

- add an `install-dependencies` command to the repository helper that runs `npm ci` from the repository root
- include the command in the helper usage output
- document running the command after lockfile changes, particularly Renovate updates

## Validation

- helper shell syntax check
- `install-dependencies` command
- `npm run lint`
- helper usage output
- generated artifact scan
